### PR TITLE
Convert rules to wrappers where possible

### DIFF
--- a/workflow/envs/fastp.yaml
+++ b/workflow/envs/fastp.yaml
@@ -1,6 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-
-dependencies:
-  - fastp =0.23.2

--- a/workflow/envs/gatk.yaml
+++ b/workflow/envs/gatk.yaml
@@ -1,6 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-
-dependencies:
-  - gatk =3.8

--- a/workflow/envs/mapping.yaml
+++ b/workflow/envs/mapping.yaml
@@ -1,8 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-  - defaults
-
-dependencies:
-  - bwa =0.7.17
-  - samtools = 1.15

--- a/workflow/envs/picard.yaml
+++ b/workflow/envs/picard.yaml
@@ -1,6 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-
-dependencies:
-  - picard =2.27

--- a/workflow/envs/qualimap.yaml
+++ b/workflow/envs/qualimap.yaml
@@ -1,6 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-
-dependencies:
-  - qualimap =2.2.2a

--- a/workflow/rules/0.1_ref_prep.smk
+++ b/workflow/rules/0.1_ref_prep.smk
@@ -29,7 +29,7 @@ rule bwa_index:
     input:
         "results/ref/{ref}/{ref}.fa",
     output:
-        idx=multiext("results/ref/{ref}/{ref}.fa", ".amb", ".ann", ".bwt", ".pac", ".sa"),
+        multiext("results/ref/{ref}/{ref}.fa", ".0123", ".amb", ".ann", ".bwt.2bit.64", ".pac"),
     log:
         "logs/ref/bwa_index/{ref}.log",
     resources:
@@ -37,7 +37,7 @@ rule bwa_index:
     benchmark:
         "benchmarks/ref/bwa_index/{ref}.log"
     wrapper:
-        "v2.4.0/bio/bwa/index"
+        "v2.6.0/bio/bwa-mem2/index"
 
 
 rule samtools_faidx:

--- a/workflow/rules/0.1_ref_prep.smk
+++ b/workflow/rules/0.1_ref_prep.smk
@@ -29,7 +29,14 @@ rule bwa_index:
     input:
         "results/ref/{ref}/{ref}.fa",
     output:
-        multiext("results/ref/{ref}/{ref}.fa", ".0123", ".amb", ".ann", ".bwt.2bit.64", ".pac"),
+        multiext(
+            "results/ref/{ref}/{ref}.fa",
+            ".0123",
+            ".amb",
+            ".ann",
+            ".bwt.2bit.64",
+            ".pac",
+        ),
     log:
         "logs/ref/bwa_index/{ref}.log",
     resources:

--- a/workflow/rules/0.1_ref_prep.smk
+++ b/workflow/rules/0.1_ref_prep.smk
@@ -29,19 +29,15 @@ rule bwa_index:
     input:
         "results/ref/{ref}/{ref}.fa",
     output:
-        multiext("results/ref/{ref}/{ref}.fa", ".amb", ".ann", ".bwt", ".pac", ".sa"),
+        idx=multiext("results/ref/{ref}/{ref}.fa", ".amb", ".ann", ".bwt", ".pac", ".sa"),
     log:
         "logs/ref/bwa_index/{ref}.log",
-    conda:
-        "../envs/mapping.yaml"
     resources:
         runtime=120,
     benchmark:
         "benchmarks/ref/bwa_index/{ref}.log"
-    shell:
-        """
-        bwa index {input} 2> {log}
-        """
+    wrapper:
+        "v2.4.0/bio/bwa/index"
 
 
 rule samtools_faidx:
@@ -52,14 +48,10 @@ rule samtools_faidx:
         "results/ref/{ref}/{ref}.fa.fai",
     log:
         "logs/ref/samtools_faidx/{ref}.log",
-    conda:
-        "../envs/samtools.yaml"
     benchmark:
         "benchmarks/ref/samtools_faidx/{ref}.log"
-    shell:
-        """
-        samtools faidx {input} 2> {log}
-        """
+    wrapper:
+        "v2.4.0/bio/samtools/faidx"
 
 
 rule ref_chunking:
@@ -88,12 +80,7 @@ rule picard_dict:
         "results/ref/{ref}/{ref}.dict",
     log:
         "logs/ref/picard_dict/{ref}.log",
-    conda:
-        "../envs/picard.yaml"
     benchmark:
         "benchmarks/ref/picard_dict/{ref}.log"
-    shell:
-        r"""
-        picard CreateSequenceDictionary -Xmx{resources.mem_mb}m \
-            R={input} O={output} 2> {log}
-        """
+    wrapper:
+        "v2.4.0/bio/picard/createsequencedictionary"

--- a/workflow/rules/1.0_preprocessing.smk
+++ b/workflow/rules/1.0_preprocessing.smk
@@ -53,8 +53,6 @@ rule fastp_pairedout:
         "logs/preprocessing/fastp/{sample}.paired.log",
     benchmark:
         "benchmarks/preprocessing/fastp/{sample}.paired.log"
-    conda:
-        "../envs/fastp.yaml"
     params:
         extra=config["params"]["fastp"]["extra"],
     threads: lambda wildcards, attempt: attempt * 2

--- a/workflow/rules/2.0_mapping.smk
+++ b/workflow/rules/2.0_mapping.smk
@@ -192,12 +192,8 @@ rule samtools_index:
         "logs/mapping/samtools/index/{prefix}.log",
     benchmark:
         "benchmarks/mapping/samtools/index/{prefix}.log"
-    conda:
-        "../envs/samtools.yaml"
-    shell:
-        """
-        samtools index {input} 2> {log}
-        """
+    wrapper:
+        "v2.6.0/bio/samtools/index"
 
 
 rule symlink_bams:

--- a/workflow/rules/2.0_mapping.smk
+++ b/workflow/rules/2.0_mapping.smk
@@ -93,13 +93,13 @@ rule bam_clipoverlap:
         runtime=lambda wildcards, attempt: attempt * 1440,
     shell:
         """
-        (samtools sort -n -o {input.bam}.namesort.bam {input.bam}
+        (samtools sort -n -T {resources.tmpdir} -o {input.bam}.namesort.bam {input.bam}
         fgbio -Xmx{resources.mem_mb}m ClipBam \
                 -i {input.bam}.namesort.bam \
                 -r {input.ref} -m {output.met} \
                 --clip-overlapping-reads=true \
                 -o {output.bam}.namesort.bam
-        samtools sort -o {output.bam} {output.bam}.namesort.bam
+        samtools sort -T {resources.tmpdir} -o {output.bam} {output.bam}.namesort.bam
         samtools index {output.bam}) 2> {log}
         """
 
@@ -130,7 +130,7 @@ rule dedup_merged:
     shell:
         """
         (dedup -i {input} -m -u -o {params.outdir}
-        samtools sort -o {output.bamfin} {output.bam}
+        samtools sort -T {resources.tmpdir} -o {output.bamfin} {output.bam}
         samtools index {output.bamfin}
         mv {params.outdir}/{wildcards.sample}.{wildcards.ref}.merged.dedup.json \
             {output.json}

--- a/workflow/rules/2.0_mapping.smk
+++ b/workflow/rules/2.0_mapping.smk
@@ -170,7 +170,7 @@ rule indelrealigner:
         dict="results/ref/{ref}/{ref}.dict",
         fai="results/ref/{ref}/{ref}.fa.fai",
     output:
-        bam="results/mapping/bams/{sample}.{ref}.rmdup.realn.bam"
+        bam="results/mapping/bams/{sample}.{ref}.rmdup.realn.bam",
     log:
         "logs/mapping/gatk/indelrealigner/{sample}.{ref}.log",
     benchmark:

--- a/workflow/rules/2.1_sample_qc.smk
+++ b/workflow/rules/2.1_sample_qc.smk
@@ -17,12 +17,8 @@ rule samtools_flagstat:
         "logs/mapping/samtools/flagstat/{prefix}.log",
     benchmark:
         "benchmarks/mapping/samtools/flagstat/{prefix}.log"
-    conda:
-        "../envs/samtools.yaml"
-    shell:
-        """
-        samtools flagstat {input} > {output} 2> {log}
-        """
+    wrapper:
+        "v2.6.0/bio/samtools/flagstat"
 
 
 rule qualimap:

--- a/workflow/rules/2.1_sample_qc.smk
+++ b/workflow/rules/2.1_sample_qc.smk
@@ -28,6 +28,7 @@ rule qualimap:
     input:
         unpack(get_final_bam),
     output:
+        directory("results/mapping/qc/qualimap/{sample}.{ref}"),
         pdf=report(
             "results/mapping/qc/qualimap/{sample}.{ref}/report.pdf",
             category="Quality Control",
@@ -36,22 +37,15 @@ rule qualimap:
         ),
         txt="results/mapping/qc/qualimap/{sample}.{ref}/genome_results.txt",
     params:
-        outdir=lambda w, output: os.path.dirname(output.txt),
-    conda:
-        "../envs/qualimap.yaml"
+        extra="-outformat pdf",
     log:
         "logs/mapping/qualimap/{sample}.{ref}.log",
     benchmark:
         "benchmarks/mapping/qualimap/{sample}.{ref}.log"
     resources:
         runtime=360,
-    shell:
-        """
-        (unset DISPLAY
-
-        qualimap bamqc --java-mem-size={resources.mem_mb}M -bam {input.bam} \
-            -outdir {params.outdir} -outformat pdf) &> {log}
-        """
+    wrapper:
+        "v2.6.0/bio/qualimap/bamqc"
 
 
 rule endo_cont:

--- a/workflow/rules/2.2_dna_damage.smk
+++ b/workflow/rules/2.2_dna_damage.smk
@@ -73,7 +73,7 @@ rule mapDamage2_rescaling:
     benchmark:
         "benchmarks/mapping/mapdamage/{sample}.{ref}.log"
     params:
-        extra="--rescale --no-stats",
+        extra="--rescale",
     resources:
         runtime=1440,
         mem_mb=lambda w, attempt: attempt * 6400,

--- a/workflow/rules/2.2_dna_damage.smk
+++ b/workflow/rules/2.2_dna_damage.smk
@@ -59,21 +59,23 @@ rule mapDamage2_rescaling:
         bam="results/mapping/bams/{sample}.{ref}.rmdup.realn.bam",
         ref="results/ref/{ref}/{ref}.fa",
     output:
-        outdir=directory("results/mapping/qc/mapdamage/{sample}.{ref}/"),
-        rescaled="results/mapping/bams/{sample}.{ref}.rmdup.realn.rescaled.bam",
+        log="results/mapping/qc/mapdamage/{sample}.{ref}/Runtime_log.txt",
+        GtoA3p="results/mapping/qc/mapdamage/{sample}.{ref}/3pGtoA_freq.txt",
+        CtoT5p="results/mapping/qc/mapdamage/{sample}.{ref}/5pCtoT_freq.txt",
+        dnacomp="results/mapping/qc/mapdamage/{sample}.{ref}/dnacomp.txt",
+        frag_misincorp="results/mapping/qc/mapdamage/{sample}.{ref}/Fragmisincorporation_plot.pdf",
+        len="results/mapping/qc/mapdamage/{sample}.{ref}/Length_plot.pdf",
+        lg_dist="results/mapping/qc/mapdamage/{sample}.{ref}/lgdistribution.txt",
+        misincorp="results/mapping/qc/mapdamage/{sample}.{ref}/misincorporation.txt",
+        rescaled_bam="results/mapping/bams/{sample}.{ref}.rmdup.realn.rescaled.bam",
     log:
         "logs/mapping/mapdamage/{sample}.{ref}.log",
     benchmark:
         "benchmarks/mapping/mapdamage/{sample}.{ref}.log"
-    container:
-        mapdamage_container
-    threads: lambda w, attempt: attempt
+    params:
+        extra="--rescale --no-stats",
     resources:
         runtime=1440,
-    params:
-        tmp="results/mapping/qc/mapdamage/{sample}.{ref}/{sample}.{ref}.rmdup.realn.rescaled.bam",
-    shell:
-        """
-        (mapDamage -i {input.bam} -r {input.ref} -d {output.outdir} --rescale
-        mv {params.tmp} {output.rescaled}) &> {log}
-        """
+        mem_mb=lambda w, attempt: attempt * 6400,
+    wrapper:
+        "v2.6.0/bio/mapdamage2"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -249,15 +249,15 @@ def get_read_group(wildcards):
 def get_dedup_bam(wildcards):
     s = wildcards.sample
     if s in samples.index[samples.time == "historical"]:
-        return [
-            "results/mapping/dedup/{sample}.{ref}.merged.rmdup.bam",
-            "results/mapping/dedup/{sample}.{ref}.merged.rmdup.bam.bai",
-        ]
+        return {
+            "bam": "results/mapping/dedup/{sample}.{ref}.merged.rmdup.bam",
+            "bai": "results/mapping/dedup/{sample}.{ref}.merged.rmdup.bam.bai",
+        }
     elif s in samples.index[samples.time == "modern"]:
-        return [
-            "results/mapping/dedup/{sample}.{ref}.clipped.rmdup.bam",
-            "results/mapping/dedup/{sample}.{ref}.clipped.rmdup.bam.bai",
-        ]
+        return {
+            "bam": "results/mapping/dedup/{sample}.{ref}.clipped.rmdup.bam",
+            "bai": "results/mapping/dedup/{sample}.{ref}.clipped.rmdup.bam.bai",
+        }
 
 
 ## Determine if bam should use Picard or DeDup for duplicate removal

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -128,7 +128,7 @@ if any(config["filter_beds"].values()):
 ## Get fastq inputs for fastp
 def get_raw_fastq(wildcards):
     unit = units.loc[wildcards.sample, ["fq1", "fq2"]]
-    return {"r1": unit.fq1, "r2": unit.fq2}
+    return {"sample": [unit.fq1, unit.fq2]}
 
 
 # Reference


### PR DESCRIPTION
To try to clean up some of the rule definitions, shell based rules that already have a snakemake wrapper have been replaced with the wrapper.