### PR TITLE
Change overlap clipping method (fgbio -> bamutil)

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -33,6 +33,9 @@ downsample_cov:
 populations: []
 
 analyses:
+  # mapping options
+  mapping:
+    historical_only_collapsed: true
   # filtering
   genmap: true
   repeatmasker:
@@ -81,7 +84,9 @@ params:
     E: "2"
     map_thresh: 1
   fastp:
-    extra: "-p -g --overlap_len_require 15"
+    extra: "-p -g" # don't put --merge or --overlap_len_require here, they're implicit
+    min_overlap_mod: 30
+    min_overlap_hist: 15
   picard:
     MarkDuplicates: "--REMOVE_DUPLICATES true --OPTICAL_DUPLICATE_PIXEL_DISTANCE 2500"
   angsd:

--- a/config/README.md
+++ b/config/README.md
@@ -150,6 +150,15 @@ settings for each analysis are set in the next section.
   analyses
 
 - `analyses:`
+  - `mapping:`
+    - `historical_only_collapsed:` Historical samples are expected to have
+      fragmented DNA. Overlapping (i.e. short) read pairs are collapsed in this
+      workflow, and while both overlapping and non-overlapping read pairs are
+      mapped for modern samples, setting this option to `true` will only map
+      the collapsed, overlapping read pairs for historical samples. This can
+      help avoid mapping contaminants, as longer fragments are likely from more
+      recent, non-endogenous DNA. However, in the event you want to map both,
+      you can set this to `false`. (`true`/`false`)
   - `genmap:` Filter out sites with low mappability estimated by Genmap
   (`true`/`false`)
   - `repeatmasker:` (NOTE: Only one of the three options should be filled/true)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -35,6 +35,9 @@ downsample_cov:
 populations: []
 
 analyses:
+  # mapping options
+  mapping:
+    historical_only_collapsed: true
   # filtering
   genmap: true
   repeatmasker:
@@ -83,7 +86,9 @@ params:
     E: "2"
     map_thresh: 1
   fastp:
-    extra: "-p -g --overlap_len_require 15"
+    extra: "-p -g" # don't put --merge or --overlap_len_require here, they're implicit
+    min_overlap_mod: 30
+    min_overlap_hist: 15
   picard:
     MarkDuplicates: "--REMOVE_DUPLICATES true --OPTICAL_DUPLICATE_PIXEL_DISTANCE 2500"
   angsd:

--- a/workflow/envs/bamutil.yaml
+++ b/workflow/envs/bamutil.yaml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - bamutil =1.0.15

--- a/workflow/rules/1.0_preprocessing.smk
+++ b/workflow/rules/1.0_preprocessing.smk
@@ -3,13 +3,13 @@
 
 
 rule fastp_mergedout:
-    """Process historical reads with fastp, collapsing overlapping read pairs"""
+    """Process reads with fastp, collapsing overlapping read pairs"""
     input:
         unpack(get_raw_fastq),
     output:
         trimmed=temp(
             expand(
-                "results/preprocessing/fastp/{{sample}}_{{unit}}_{{lib}}.{read}.discard.fastq.gz",
+                "results/preprocessing/fastp/{{sample}}_{{unit}}_{{lib}}.{read}.fastq.gz",
                 read=["R1", "R2"],
             )
         ),
@@ -27,11 +27,12 @@ rule fastp_mergedout:
         ),
         json="results/preprocessing/qc/fastp/{sample}_{unit}_{lib}_paired.json",
     log:
-        "logs/preprocessing/fastp/{sample}_{unit}_{lib}.merged.log",
+        "logs/preprocessing/fastp/{sample}_{unit}_{lib}.log",
     benchmark:
-        "benchmarks/preprocessing/fastp/{sample}_{unit}_{lib}.merged.log"
+        "benchmarks/preprocessing/fastp/{sample}_{unit}_{lib}.log"
     params:
-        extra=config["params"]["fastp"]["extra"] + " --merge",
+        extra=lambda w: config["params"]["fastp"]["extra"]
+        + f" --merge --overlap_len_require {get_min_overlap(w)}",
     threads: lambda wildcards, attempt: attempt * 2
     resources:
         runtime=lambda wildcards, attempt: attempt * 240,
@@ -39,37 +40,37 @@ rule fastp_mergedout:
         "v2.5.0/bio/fastp"
 
 
-rule fastp_pairedout:
-    """Process modern reads with fastp, trimming adapters and low quality bases"""
-    input:
-        unpack(get_raw_fastq),
-    output:
-        trimmed=temp(
-            expand(
-                "results/preprocessing/fastp/{{sample}}_{{unit}}_{{lib}}.{read}.fastq.gz",
-                read=["R1", "R2"],
-            )
-        ),
-        html=report(
-            "results/preprocessing/qc/fastp/{sample}_{unit}_{lib}_paired.html",
-            category="Quality Control",
-            subcategory="Trimming Reports",
-            labels={
-                "Sample": "{sample}",
-                "Unit": "{unit}",
-                "Lib": "{lib}",
-                "Type": "fastp Report",
-            },
-        ),
-        json="results/preprocessing/qc/fastp/{sample}_{unit}_{lib}_paired.json",
-    log:
-        "logs/preprocessing/fastp/{sample}_{unit}_{lib}.paired.log",
-    benchmark:
-        "benchmarks/preprocessing/fastp/{sample}_{unit}_{lib}.paired.log"
-    params:
-        extra=config["params"]["fastp"]["extra"],
-    threads: lambda wildcards, attempt: attempt * 2
-    resources:
-        runtime=lambda wildcards, attempt: attempt * 240,
-    wrapper:
-        "v2.5.0/bio/fastp"
+# rule fastp_pairedout:
+#     """Process modern reads with fastp, trimming adapters and low quality bases"""
+#     input:
+#         unpack(get_raw_fastq),
+#     output:
+#         trimmed=temp(
+#             expand(
+#                 "results/preprocessing/fastp/{{sample}}_{{unit}}_{{lib}}.{read}.fastq.gz",
+#                 read=["R1", "R2"],
+#             )
+#         ),
+#         html=report(
+#             "results/preprocessing/qc/fastp/{sample}_{unit}_{lib}_paired.html",
+#             category="Quality Control",
+#             subcategory="Trimming Reports",
+#             labels={
+#                 "Sample": "{sample}",
+#                 "Unit": "{unit}",
+#                 "Lib": "{lib}",
+#                 "Type": "fastp Report",
+#             },
+#         ),
+#         json="results/preprocessing/qc/fastp/{sample}_{unit}_{lib}_paired.json",
+#     log:
+#         "logs/preprocessing/fastp/{sample}_{unit}_{lib}.paired.log",
+#     benchmark:
+#         "benchmarks/preprocessing/fastp/{sample}_{unit}_{lib}.paired.log"
+#     params:
+#         extra=config["params"]["fastp"]["extra"],
+#     threads: lambda wildcards, attempt: attempt * 2
+#     resources:
+#         runtime=lambda wildcards, attempt: attempt * 240,
+#     wrapper:
+#         "v2.5.0/bio/fastp"

--- a/workflow/rules/2.0_mapping.smk
+++ b/workflow/rules/2.0_mapping.smk
@@ -48,7 +48,7 @@ rule bwa_mem_paired:
         "v2.6.0/bio/bwa/mem"
 
 
-rule samtools_merge:
+rule samtools_merge_units:
     input:
         get_sample_bams,
     output:
@@ -90,39 +90,6 @@ rule mark_duplicates:
         "v1.17.2/bio/picard/markduplicates"
 
 
-rule bam_clipoverlap:
-    """Clip overlapping reads in paired end bam files"""
-    input:
-        bam="results/mapping/dedup/{sample}.{ref}.paired.rmdup.bam",
-        ref="results/ref/{ref}/{ref}.fa",
-    output:
-        bam=temp("results/mapping/dedup/{sample}.{ref}.clipped.rmdup.bam"),
-        bai=temp("results/mapping/dedup/{sample}.{ref}.clipped.rmdup.bam.bai"),
-        met="results/mapping/qc/fgbio_clipbam/{sample}.{ref}.fgbio_clip.metrics",
-    log:
-        "logs/mapping/fgbio/clipbam/{sample}.{ref}.log",
-    benchmark:
-        "benchmarks/mapping/fgbio/clipbam/{sample}.{ref}.log"
-    conda:
-        "../envs/fgbio.yaml"
-    shadow:
-        "minimal"
-    threads: lambda wildcards, attempt: attempt * 2
-    resources:
-        runtime=lambda wildcards, attempt: attempt * 1440,
-    shell:
-        """
-        (samtools sort -n -T {resources.tmpdir} -o {input.bam}.namesort.bam {input.bam}
-        fgbio -Xmx{resources.mem_mb}m ClipBam \
-                -i {input.bam}.namesort.bam \
-                -r {input.ref} -m {output.met} \
-                --clip-overlapping-reads=true \
-                -o {output.bam}.namesort.bam
-        samtools sort -T {resources.tmpdir} -o {output.bam} {output.bam}.namesort.bam
-        samtools index {output.bam}) 2> {log}
-        """
-
-
 rule dedup_merged:
     """Remove duplicates from collapsed read bam files"""
     input:
@@ -160,10 +127,27 @@ rule dedup_merged:
         """
 
 
+rule samtools_merge_dedup:
+    input:
+        get_dedup_bams,
+    output:
+        bam=temp("results/mapping/dedup/{sample}.{ref}.rmdup.bam"),
+    log:
+        "logs/mapping/samtools/merge/{sample}.{ref}.rmdup.log",
+    benchmark:
+        "benchmarks/mapping/samtools/{sample}.{ref}.rmdup.log"
+    threads: lambda wildcards, attempt: attempt * 4
+    resources:
+        runtime=lambda wildcards, attempt: attempt * 720,
+    wrapper:
+        "v2.6.0/bio/samtools/merge"
+
+
 rule realignertargetcreator:
     """Create intervals database for GATK Indel Realigner"""
     input:
-        unpack(get_dedup_bam),
+        bam="results/mapping/dedup/{sample}.{ref}.rmdup.bam",
+        bai="results/mapping/dedup/{sample}.{ref}.rmdup.bam.bai",
         ref="results/ref/{ref}/{ref}.fa",
         dict="results/ref/{ref}/{ref}.dict",
         fai="results/ref/{ref}/{ref}.fa.fai",
@@ -183,13 +167,14 @@ rule realignertargetcreator:
 rule indelrealigner:
     """Realign reads around indels"""
     input:
-        unpack(get_dedup_bam),
+        bam="results/mapping/dedup/{sample}.{ref}.rmdup.bam",
+        bai="results/mapping/dedup/{sample}.{ref}.rmdup.bam.bai",
         target_intervals="results/mapping/indelrealign/{sample}.{ref}.rmdup.intervals",
         ref="results/ref/{ref}/{ref}.fa",
         dict="results/ref/{ref}/{ref}.dict",
         fai="results/ref/{ref}/{ref}.fa.fai",
     output:
-        bam="results/mapping/bams/{sample}.{ref}.rmdup.realn.bam",
+        bam=temp("results/mapping/indelrealign/{sample}.{ref}.rmdup.realn.bam"),
     log:
         "logs/mapping/gatk/indelrealigner/{sample}.{ref}.log",
     benchmark:
@@ -201,12 +186,53 @@ rule indelrealigner:
         "v2.6.0/bio/gatk3/indelrealigner"
 
 
+rule bam_clipoverlap:
+    """Clip overlapping reads in paired end bam files"""
+    input:
+        bam="results/mapping/indelrealign/{sample}.{ref}.rmdup.realn.bam",
+        ref="results/ref/{ref}/{ref}.fa",
+    output:
+        bam="results/mapping/bams/{sample}.{ref}.rmdup.realn.clip.bam",
+        # met="results/mapping/qc/fgbio_clipbam/{sample}.{ref}.fgbio_clip.metrics",
+        log="results/mapping/qc/bamutil_clipoverlap/{sample}.{ref}.clipoverlap.stats"
+    log:
+        # "logs/mapping/fgbio/clipbam/{sample}.{ref}.log",
+        "logs/mapping/bamutil/clipoverlap/{sample}.{ref}.log",
+    benchmark:
+        # "benchmarks/mapping/fgbio/clipbam/{sample}.{ref}.log"
+        "benchmarks/mapping/bamutil/clipoverlap/{sample}.{ref}.log"
+    conda:
+        # "../envs/fgbio.yaml"
+        "../envs/bamutil.yaml"
+    shadow:
+        "minimal"
+    threads: lambda wildcards, attempt: attempt * 2
+    resources:
+        runtime=lambda wildcards, attempt: attempt * 1440,
+    # shell:
+    #     """
+    #     (samtools sort -n -T {resources.tmpdir} -o {input.bam}.namesort.bam {input.bam}
+    #     fgbio -Xmx{resources.mem_mb}m ClipBam \
+    #             -i {input.bam}.namesort.bam \
+    #             -r {input.ref} -m {output.met} \
+    #             --clip-overlapping-reads=true \
+    #             -o {output.bam}.namesort.bam
+    #     samtools sort -T {resources.tmpdir} -o {output.bam} {output.bam}.namesort.bam
+    #     samtools index {output.bam}) 2> {log}
+    #     """
+    shell:
+        """
+        bam clipOverlap --in {input.bam} --out {output.bam} --stats 2> {log}
+        cat {log} > {output.log}
+        """
+
+
 rule samtools_index:
     """Index bam files """
     input:
-        "results/mapping/bams/{prefix}.bam",
+        "results/mapping/{prefix}.bam",
     output:
-        "results/mapping/bams/{prefix}.bam.bai",
+        "results/mapping/{prefix}.bam.bai",
     log:
         "logs/mapping/samtools/index/{prefix}.log",
     benchmark:

--- a/workflow/rules/2.0_mapping.smk
+++ b/workflow/rules/2.0_mapping.smk
@@ -194,7 +194,7 @@ rule bam_clipoverlap:
     output:
         bam="results/mapping/bams/{sample}.{ref}.rmdup.realn.clip.bam",
         # met="results/mapping/qc/fgbio_clipbam/{sample}.{ref}.fgbio_clip.metrics",
-        log="results/mapping/qc/bamutil_clipoverlap/{sample}.{ref}.clipoverlap.stats"
+        log="results/mapping/qc/bamutil_clipoverlap/{sample}.{ref}.clipoverlap.stats",
     log:
         # "logs/mapping/fgbio/clipbam/{sample}.{ref}.log",
         "logs/mapping/bamutil/clipoverlap/{sample}.{ref}.log",

--- a/workflow/rules/2.1_sample_qc.smk
+++ b/workflow/rules/2.1_sample_qc.smk
@@ -54,28 +54,17 @@ rule endo_cont:
     content.
     """
     input:
-        get_endo_cont_stat,
+        unpack(get_endo_cont_stat),
     output:
-        "results/mapping/qc/endogenous_content/{sample}.{ref}.endo",
+        endo="results/mapping/qc/endogenous_content/{sample}.{ref}.endo",
     conda:
         "../envs/shell.yaml"
     log:
         "logs/mapping/endogenous_content/{sample}.{ref}.log",
     benchmark:
         "benchmarks/mapping/endogenous_content/{sample}.{ref}.log"
-    shell:
-        r"""
-        (total=$(grep -E "^[0-9]+ \+ [0-9]+ in total" {input} \
-            | awk '{{print $1}}')
-        mapped=$(grep -E "^[0-9]+ \+ [0-9]+ mapped" {input} \
-            | awk '{{print $1}}')
-        primary=$(grep -E "^[0-9]+ \+ [0-9]+ primary mapped" {input} \
-            | awk '{{print $1}}')
-
-        echo $total $mapped $primary {wildcards.sample} | \
-            awk '{{printf "%s\t%.3f\t%.3f\n",$4,$2/$1*100,$3/$1*100}}' \
-            > {output}) 2> {log}
-        """
+    script:
+        "../scripts/calc_endocont.sh"
 
 
 rule compile_endo_cont:
@@ -99,7 +88,7 @@ rule compile_endo_cont:
         runtime=lambda wildcards, attempt: attempt * 15,
     shell:
         """
-        (printf "sample\tperc.map\tperc.prim.map\n" > {output}
+        (printf "sample\tperc.merged.map\tperc.paired.map\tperc.total.map\n" > {output}
         cat {input} >> {output}) 2> {log}
         """
 

--- a/workflow/rules/2.2_dna_damage.smk
+++ b/workflow/rules/2.2_dna_damage.smk
@@ -7,7 +7,7 @@ rule damageprofiler:
     rather than corrective.
     """
     input:
-        bam="results/mapping/bams/{sample}.{ref}.rmdup.realn.bam",
+        bam="results/mapping/bams/{sample}.{ref}.rmdup.realn.clip.bam",
         ref="results/ref/{ref}/{ref}.fa",
     output:
         multiext(
@@ -56,7 +56,7 @@ rule mapDamage2_rescaling:
     quality scores to correct for damage.
     """
     input:
-        bam="results/mapping/bams/{sample}.{ref}.rmdup.realn.bam",
+        bam="results/mapping/bams/{sample}.{ref}.rmdup.realn.clip.bam",
         ref="results/ref/{ref}/{ref}.fa",
     output:
         log="results/mapping/qc/mapdamage/{sample}.{ref}/Runtime_log.txt",
@@ -67,7 +67,7 @@ rule mapDamage2_rescaling:
         len="results/mapping/qc/mapdamage/{sample}.{ref}/Length_plot.pdf",
         lg_dist="results/mapping/qc/mapdamage/{sample}.{ref}/lgdistribution.txt",
         misincorp="results/mapping/qc/mapdamage/{sample}.{ref}/misincorporation.txt",
-        rescaled_bam="results/mapping/bams/{sample}.{ref}.rmdup.realn.rescaled.bam",
+        rescaled_bam="results/mapping/bams/{sample}.{ref}.rmdup.realn.clip.rescaled.bam",
     log:
         "logs/mapping/mapdamage/{sample}.{ref}.log",
     benchmark:

--- a/workflow/scripts/calc_endocont.sh
+++ b/workflow/scripts/calc_endocont.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+(merged="${snakemake_input[merged]}"
+paired="${snakemake_input[paired]}"
+
+tot_merged=$(grep -E "^[0-9]+ \+ [0-9]+ in total" $merged | awk '{print $1}')
+map_merged=$(grep -E "^[0-9]+ \+ [0-9]+ mapped" $merged | awk '{print $1}')
+if [ $tot_merged == 0 ]; then
+    perc_merged="No merged reads..."
+else
+    perc_merged=$(echo $tot_merged $map_merged | awk '{printf "%.2f", $2/$1*100}')
+fi
+
+if [ "$merged" == "$paired" ]; then
+    tot_paired="NA"
+    map_paired="NA"
+    perc_paired="NA"
+    tot_tot="$tot_merged"
+    map_tot="$map_merged"
+else
+    tot_paired=$(grep -E "^[0-9]+ \+ [0-9]+ in total" $paired | awk '{print $1}')
+    map_paired=$(grep -E "^[0-9]+ \+ [0-9]+ mapped" $paired | awk '{print $1}')
+    if [ $tot_paired == 0 ]; then
+        perc_paired="No paired reads..."
+    else
+        perc_paired=$(echo $tot_paired $map_paired | awk '{printf "%.2f", $2/$1*100}')
+    fi
+    tot_tot=$(echo $tot_merged"+"$tot_paired | bc)
+    map_tot=$(echo $map_merged"+"$map_paired | bc)
+fi
+
+if [ $tot_tot == 0 ]; then
+    perc_tot="No reads..."
+else
+    perc_tot=$(echo $tot_tot $map_tot | awk '{printf "%.2f", $2/$1*100}')
+fi
+
+
+echo -e "${snakemake_wildcards[sample]}\t"$perc_merged"\t"$perc_paired"\t"$perc_tot \
+    > "${snakemake_output[endo]}") 2> "${snakemake_log[0]}"


### PR DESCRIPTION
Change how overlapping reads are handled overall.

ANGSD will double count overlapping reads, which may lead to counting some positions as higher depth than they actually are, and may increase genotype confidence in a biased way (see [Lou et al. 2021; Mol Ecol](https://doi.org/10.1111/mec.16077); Table 3).

fgbio clipbam would clip overlapping reads, but didn't take into account the base quality, sometimes clipping the higher quality read. bamutil clips the read with the lower average quality, which helps prevent this in many cases.

Additionally, overlapping read merging is now done for all samples in fastp, which uses the highest quality read when merging the overlapping region.