### PR TITLE
Pileup mappability

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -37,7 +37,7 @@ analyses:
   mapping:
     historical_only_collapsed: true
   # filtering
-  genmap: true
+  pileup-mappability: true
   repeatmasker:
     local_lib:
     dfam_lib:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -39,7 +39,7 @@ analyses:
   mapping:
     historical_only_collapsed: true
   # filtering
-  genmap: true
+  pileup-mappability: true
   repeatmasker:
     local_lib:
     dfam_lib:
@@ -79,7 +79,7 @@ only_filter_beds: false
 mapQ: 30
 baseQ: 30
 
-params:: true
+params: true
   genmap:
     K: "100"
     E: "2"

--- a/workflow/envs/bedops.yaml
+++ b/workflow/envs/bedops.yaml
@@ -1,0 +1,10 @@
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - bedops =2.4.41
+  - gawk
+  - coreutils
+  - gzip
+  - grep

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -197,9 +197,23 @@ def get_bed_filts(wildcards):
             "results/datasets/{dataset}/filters/sex-link_mito_excl/{ref}_excl.bed.sum"
         )
     # add mappability filter if set
-    if config["analyses"]["genmap"]:
-        bedin.append("results/datasets/{dataset}/filters/lowmap/{ref}_lowmap.bed")
-        bedsum.append("results/datasets/{dataset}/filters/lowmap/{ref}_lowmap.bed.sum")
+    if config["analyses"]["pileup-mappability"]:
+        bedin.extend(
+            expand(
+                "results/datasets/{{dataset}}/filters/pileupmap/{{ref}}_k{k}_e{e}_{thresh}.bed",
+                k=config["params"]["genmap"]["K"],
+                e=config["params"]["genmap"]["E"],
+                thresh=config["params"]["genmap"]["map_thresh"],
+            )
+        )
+        bedsum.extend(
+            expand(
+                "results/datasets/{{dataset}}/filters/pileupmap/{{ref}}_k{k}_e{e}_{thresh}.bed.sum",
+                k=config["params"]["genmap"]["K"],
+                e=config["params"]["genmap"]["E"],
+                thresh=config["params"]["genmap"]["map_thresh"],
+            )
+        )
     # add repeat filter if set
     if any(config["analyses"]["repeatmasker"].values()):
         bedin.append("results/ref/{ref}/repeatmasker/{ref}.fa.out.gff")


### PR DESCRIPTION
The previous mappability filter was a bit rough in how it addressed mappability, as it only really addressed if a read could uniquely map when starting at a given position. This doesn't really tell about how all the potential reads that can cross a position can map to it. Now the filter uses pileup mappability (see reference below), which averages the mappability of all possible k-mers overlapping a position. This should be more appropriate for telling how well a position can be mapped to with short read data. Setting K to a value close to historical DNA fragment sizes will hopefully make sure that modern and historical samples are getting fairly compared.


Fast Computation and Applications of Genome Mappability - Scientific Figure on ResearchGate. Available from: https://www.researchgate.net/figure/Pileup-mappability-The-number-of-all-possible-k-mers-covering-a-particular-position-of_fig4_221776385 [accessed 8 Dec, 2023]