### PR TITLE
Allow user input repeat bed files

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -40,6 +40,7 @@ analyses:
   # filtering
   pileup-mappability: true
   repeatmasker:
+    bed:
     local_lib:
     dfam_lib:
     build_lib: true

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ when you start with raw sequencing data or with processed BAM files.
 
 Additionally, several data filtering options are available:
 
-- Identification and removal of repetitive regions
+- Identification (can also skip identification if repeat bed/gff is supplied)
+  and removal of repetitive regions
 - Removal of regions with low mappability for fragments of a specified size
 - Removal of regions with extreme high or low depth
 - Removal of regions with a certain amount of missing data

--- a/config/README.md
+++ b/config/README.md
@@ -170,8 +170,16 @@ settings for each analysis are set in the next section.
   - `genmap:` Filter out sites with low mappability estimated by Genmap
   (`true`/`false`)
   - `repeatmasker:` (NOTE: Only one of the three options should be filled/true)
+    - `bed:` Supply a path to a bed file that contains regions with repeats.
+      This is for those who want to filter out repetitive content, but don't
+      need to run Repeatmodeler or masker in the workflow because it has
+      already been done for the genome you're using. Be sure the contig names
+      in the bed file match those in the reference supplied. GFF or other
+      filetypes that work with `bedtools subtract` may also work, but haven't
+      been tested.
     - `local_lib:` Filter repeats by masking with an already made library you
-      have locally. Should be file path.
+      have locally (such as ones downloaded for Darwin Tree of Life genomes).
+      Should be file path, not a URL.
     - `dfam_lib:` Filter repeats using a library available from dfam. Should be
       a taxonomic group name.
     - `build_lib:` Use RepeatModeler to build a library of repeats from the

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -42,6 +42,7 @@ analyses:
   # filtering
   pileup-mappability: true
   repeatmasker:
+    bed:
     local_lib:
     dfam_lib:
     build_lib: true

--- a/workflow/rules/0.2_ref_filt.smk
+++ b/workflow/rules/0.2_ref_filt.smk
@@ -342,10 +342,10 @@ rule repeatmasker:
 rule repeat_sum:
     """Summarize the proportion of the genome contained in the repeat gff"""
     input:
+        unpack(get_rep_file),
         sum="results/ref/{ref}/beds/genome.bed.sum",
-        gff="results/ref/{ref}/repeatmasker/{ref}.fa.out.gff",
     output:
-        sum="results/ref/{ref}/repeatmasker/{ref}.fa.out.gff.sum",
+        sum="results/ref/{ref}/repeatmasker/{ref}.fa.out.sum",
         bed="results/ref/{ref}/repeatmasker/{ref}.fa.out.bed",
     log:
         "logs/ref/repeatmasker/summarize_gff/{ref}.log",
@@ -355,7 +355,7 @@ rule repeat_sum:
         "../envs/bedtools.yaml"
     shell:
         r"""
-        (bedtools merge -i {input.gff} > {output.bed}
+        (bedtools merge -i {input.rep} > {output.bed}
         len=$(awk 'BEGIN{{SUM=0}}{{SUM+=$3-$2}}END{{print SUM}}' {output.bed})
         echo $len $(awk -F "\t" '{{print $2}}' {input.sum}) | \
             awk '{{print "Repeats\t"$2-$1"\t"($2-$1)/$2*100}}' > {output.sum}) &> {log}

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -175,6 +175,13 @@ def get_repmaskin(wildcards):
     return dic
 
 
+## Determine if making repeat bed or using user supplied
+def get_rep_file(wildcards):
+    if config["analyses"]["repeatmasker"]["bed"]:
+        return {"rep": config["analyses"]["repeatmasker"]["bed"]}
+    return {"rep": "results/ref/{ref}/repeatmasker/{ref}.fa.out.gff"}
+
+
 ## Get inputs for combined filters file
 def get_bed_filts(wildcards):
     bedin = []
@@ -225,8 +232,8 @@ def get_bed_filts(wildcards):
         )
     # add repeat filter if set
     if any(config["analyses"]["repeatmasker"].values()):
-        bedin.append("results/ref/{ref}/repeatmasker/{ref}.fa.out.gff")
-        bedsum.append("results/ref/{ref}/repeatmasker/{ref}.fa.out.gff.sum")
+        bedin.append("results/ref/{ref}/repeatmasker/{ref}.fa.out.bed")
+        bedsum.append("results/ref/{ref}/repeatmasker/{ref}.fa.out.sum")
     # add global depth extremes filter if set
     if config["analyses"]["extreme_depth"]:
         if (


### PR DESCRIPTION
Avoids having to run repeatmodeler/masker if it has already been run elsewhere for a genome and a bed/gff file can be provided.