### PR TITLE
Fix: Ensure libraries are deduped separately in historical samples

### DIFF
--- a/.test/config/units.tsv
+++ b/.test/config/units.tsv
@@ -1,6 +1,6 @@
 sample	unit	lib	platform	fq1	fq2	bam	sra	realname
 hist1	BHVN22DSX2.2	hist1	ILLUMINA	data/fastq/hist1.r1.fastq.gz	data/fastq/hist1.r2.fastq.gz			MZLU153040
-hist1	BHVN22DSX2.3	hist1	ILLUMINA	data/fastq/hist1.unit2.r1.fastq.gz	data/fastq/hist1.unit2.r2.fastq.gz			MZLU153040
+hist1	BHVN22DSX2.3	hist1a	ILLUMINA	data/fastq/hist1.unit2.r1.fastq.gz	data/fastq/hist1.unit2.r2.fastq.gz			MZLU153040
 hist2	BHVN22DSX2.2	hist2	ILLUMINA	data/fastq/hist2.r1.fastq.gz	data/fastq/hist2.r2.fastq.gz			MZLU153042
 hist3	BHVN22DSX2.2	hist2	ILLUMINA	data/fastq/hist3.r1.fastq.gz	data/fastq/hist3.r2.fastq.gz			MZLU153045
 mod1	AHW5NGDSX2.3	mod1	ILLUMINA	data/fastq/mod1.r1.fastq.gz	data/fastq/mod1.r2.fastq.gz			MZLU107434

--- a/workflow/rules/2.0_mapping.smk
+++ b/workflow/rules/2.0_mapping.smk
@@ -96,18 +96,32 @@ rule bwa_mem_merged:
         "v2.6.0/bio/bwa/mem"
 
 
-rule samtools_merge_units:
+rule samtools_merge_collapsed_libs:
     input:
-        get_sample_bams,
+        get_lib_bams,
     output:
-        bam=temp("results/mapping/mapped/{sample}.{ref}.{pairing}.bam"),
+        bam=temp("results/mapping/mapped/{sample}_{lib}.{ref}.merged.bam"),
     log:
-        "logs/mapping/samtools/merge/{sample}.{ref}.{pairing}.log",
+        "logs/mapping/samtools/merge/{sample}_{lib}.{ref}.merged.log"
     benchmark:
-        "benchmarks/mapping/samtools/{sample}.{ref}.{pairing}.log"
+        "benchmarks/mapping/samtools/merge/{sample}_{lib}.{ref}.merged.log"
     threads: lambda wildcards, attempt: attempt * 4
-    wildcard_constraints:
-        pairing="merged|paired",
+    resources:
+        runtime=lambda wildcards, attempt: attempt * 720,
+    wrapper:
+        "v2.6.0/bio/samtools/merge"
+
+
+rule samtools_merge_paired_units:
+    input:
+        get_paired_bams,
+    output:
+        bam=temp("results/mapping/mapped/{sample}.{ref}.paired.bam"),
+    log:
+        "logs/mapping/samtools/merge/{sample}.{ref}.paired.log",
+    benchmark:
+        "benchmarks/mapping/samtools/{sample}.{ref}.paired.log"
+    threads: lambda wildcards, attempt: attempt * 4
     resources:
         runtime=lambda wildcards, attempt: attempt * 720,
     wrapper:
@@ -139,18 +153,18 @@ rule mark_duplicates:
 rule dedup_merged:
     """Remove duplicates from collapsed read bam files"""
     input:
-        "results/mapping/mapped/{sample}.{ref}.merged.bam",
+        "results/mapping/mapped/{sample}_{lib}.{ref}.merged.bam",
     output:
-        json="results/mapping/qc/dedup/{sample}.{ref}.dedup.json",
-        hist="results/mapping/qc/dedup/{sample}.{ref}.dedup.hist",
-        log="results/mapping/qc/dedup/{sample}.{ref}.dedup.log",
-        bam=temp("results/mapping/dedup/{sample}.{ref}.merged_rmdup.bam"),
-        bamfin=temp("results/mapping/dedup/{sample}.{ref}.merged.rmdup.bam"),
-        bai=temp("results/mapping/dedup/{sample}.{ref}.merged.rmdup.bam.bai"),
+        json="results/mapping/qc/dedup/{sample}_{lib}.{ref}.dedup.json",
+        hist="results/mapping/qc/dedup/{sample}_{lib}.{ref}.dedup.hist",
+        log="results/mapping/qc/dedup/{sample}_{lib}.{ref}.dedup.log",
+        bam=temp("results/mapping/dedup/{sample}_{lib}.{ref}.merged_rmdup.bam"),
+        bamfin=temp("results/mapping/dedup/{sample}_{lib}.{ref}.merged.rmdup.bam"),
+        bai=temp("results/mapping/dedup/{sample}_{lib}.{ref}.merged.rmdup.bam.bai"),
     log:
-        "logs/mapping/dedup/{sample}.{ref}.merged.log",
+        "logs/mapping/dedup/{sample}_{lib}.{ref}.merged.log",
     benchmark:
-        "benchmarks/mapping/dedup/{sample}.{ref}.merged.log"
+        "benchmarks/mapping/dedup/{sample}_{lib}.{ref}.merged.log"
     conda:
         "../envs/dedup.yaml"
     shadow:
@@ -165,11 +179,11 @@ rule dedup_merged:
         (dedup -i {input} -m -u -o {params.outdir}
         samtools sort -T {resources.tmpdir} -o {output.bamfin} {output.bam}
         samtools index {output.bamfin}
-        mv {params.outdir}/{wildcards.sample}.{wildcards.ref}.merged.dedup.json \
+        mv {params.outdir}/{wildcards.sample}_{wildcards.lib}.{wildcards.ref}.merged.dedup.json \
             {output.json}
-        mv {params.outdir}/{wildcards.sample}.{wildcards.ref}.merged.hist \
+        mv {params.outdir}/{wildcards.sample}_{wildcards.lib}.{wildcards.ref}.merged.hist \
             {output.hist}
-        mv {params.outdir}/{wildcards.sample}.{wildcards.ref}.merged.log \
+        mv {params.outdir}/{wildcards.sample}_{wildcards.lib}.{wildcards.ref}.merged.log \
             {output.log}) &> {log}
         """
 

--- a/workflow/rules/2.0_mapping.smk
+++ b/workflow/rules/2.0_mapping.smk
@@ -102,7 +102,7 @@ rule samtools_merge_collapsed_libs:
     output:
         bam=temp("results/mapping/mapped/{sample}_{lib}.{ref}.merged.bam"),
     log:
-        "logs/mapping/samtools/merge/{sample}_{lib}.{ref}.merged.log"
+        "logs/mapping/samtools/merge/{sample}_{lib}.{ref}.merged.log",
     benchmark:
         "benchmarks/mapping/samtools/merge/{sample}_{lib}.{ref}.merged.log"
     threads: lambda wildcards, attempt: attempt * 4

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -468,11 +468,20 @@ def get_endo_cont_stat(wildcards):
             "merged": "results/mapping/user-provided-bams/{sample}.{ref}.user-processed.flagstat",
         }
     if s in samples.index[samples.time == "historical"]:
+        libs = list(set(units.loc[units["sample"] == wildcards.sample]["lib"]))
         if config["analyses"]["mapping"]["historical_only_collapsed"]:
-            return {"merged": "results/mapping/mapped/{sample}.{ref}.merged.flagstat"}
+            return {
+                "merged": expand(
+                    "results/mapping/mapped/{{sample}}_{lib}.{{ref}}.merged.flagstat",
+                    lib=libs,
+                )
+            }
         return {
             "paired": "results/mapping/mapped/{sample}.{ref}.paired.flagstat",
-            "merged": "results/mapping/mapped/{sample}.{ref}.merged.flagstat",
+            "merged": expand(
+                "results/mapping/mapped/{{sample}}_{lib}.{{ref}}.merged.flagstat",
+                lib=libs,
+            ),
         }
     return {"paired": "results/mapping/mapped/{sample}.{ref}.paired.flagstat"}
 

--- a/workflow/scripts/calc_endocont.sh
+++ b/workflow/scripts/calc_endocont.sh
@@ -8,8 +8,8 @@ if [[ -z "$merged" ]]; then
     map_merged=0
     perc_merged="NA"
 else
-    tot_merged=$(grep -E "^[0-9]+ \+ [0-9]+ in total" $merged | awk '{print $1}')
-    map_merged=$(grep -E "^[0-9]+ \+ [0-9]+ mapped" $merged | awk '{print $1}')
+    tot_merged=$(grep -h -E "^[0-9]+ \+ [0-9]+ in total" $merged | awk '{sum+=$1;} END{print sum;}')
+    map_merged=$(grep -h -E "^[0-9]+ \+ [0-9]+ mapped" $merged | awk '{sum+=$1;} END{print sum;}')
     if [ $tot_merged == 0 ]; then
         perc_merged="No reads collapsed..."
     else


### PR DESCRIPTION
I am uncertain if dedup pays attention to the LB read group when deduplicating like Picard does. To ensure that duplicates are removed separately per library, sequencing runs are merged by library identifier for a sample, deduplicated, and then merged into one sample bam.