### PR TITLE
Allow filtering with -minInd in ANGSD

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -35,7 +35,7 @@ analyses:
   mapping:
     historical_only_collapsed: false
     historical_collapsed_aligner: "aln"
-  # filtering
+  # sites file filters
   pileup-mappability: true
   repeatmasker:
     bed:
@@ -133,16 +133,18 @@ params:
     profile_modern: false
   angsd:
     gl_model: 2 # gl_model - 1=SAMtools, 2=GATK, 3=SOAPsnp, 4=SYK
-    maxdepth: 1000
-    missing_data_mindepthind: 1
-    extra: ""
-    extra_saf: ""
-    extra_beagle: ""
+    maxdepth: 1000 # for depth calc only
+    mindepthind: 1
+    minind_dataset: 0.75 # as a proportion of N
+    minind_pop: 0.5 # as a proportion of N
+    extra: "" # goes to all ANGSD runs
+    extra_saf: "" # goes to all -doSaf runs
+    extra_beagle: "" # goes to all -doGlf 2 runs
     domajorminor: 1 # Currently only compatible with values 1, 2, 4, 5
     domaf: 1
     snp_pval: "1e-6"
     min_maf: -1 # Set -1 to disable
-    mindepthind_heterozygosity: 3
+    mindepthind_heterozygosity: 1
   ngsld:
     max_kb_dist_est-ld: 200
     rnd_sample_est-ld: 0.001

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -35,7 +35,7 @@ analyses:
   mapping:
     historical_only_collapsed: true
     historical_collapsed_aligner: "aln"
-  # filtering
+  # sites file filters
   pileup-mappability: true
   repeatmasker:
     bed:
@@ -43,8 +43,8 @@ analyses:
     dfam_lib:
     build_lib: true
   extreme_depth: true
-  dataset_missing_data: 0.8
-  population_missing_data: 0.8
+  dataset_missing_data:
+  population_missing_data:
   # quality control
   qualimap: true
   damageprofiler: true
@@ -132,16 +132,18 @@ params:
     profile_modern: false
   angsd:
     gl_model: 2 # gl_model - 1=SAMtools, 2=GATK, 3=SOAPsnp, 4=SYK
-    maxdepth: 1000
-    missing_data_mindepthind: 1
-    extra: ""
-    extra_saf: ""
-    extra_beagle: ""
+    maxdepth: 1000 # for depth calc only
+    mindepthind: 1
+    minind_dataset: 0.75 # as a proportion of N
+    minind_pop: 0.75 # as a proportion of N
+    extra: "" # goes to all ANGSD runs
+    extra_saf: "" # goes to all -doSaf runs
+    extra_beagle: "" # goes to all -doGlf 2 runs
     domajorminor: 1 # Currently only compatible with values 1, 2, 4, 5
     domaf: 1
     snp_pval: "1e-6"
     min_maf: -1 # Set -1 to disable
-    mindepthind_heterozygosity: 3
+    mindepthind_heterozygosity: 1
   ngsld:
     max_kb_dist_est-ld: 4000
     rnd_sample_est-ld: 0.001

--- a/docs/config.md
+++ b/docs/config.md
@@ -159,7 +159,7 @@ Required configuration of the reference.
   reference genome. This is optional, and is used to polarize allele
   frequencies in SAF files to ancestral/derived. If you leave this empty,
   the reference genome itself will be used as ancestral, and you should be
-  sure the [`params`] [`realSFS`] [`fold`] is set to `1`. If you put a reference
+  sure the [`params`] [`realSFS`] [`fold`] is set to `1`. If you put a fasta
   here, you can set that to `0`.
 
 Reference genomes should be uncompressed, and contig names should be clear and
@@ -196,26 +196,27 @@ settings for each analysis are set in the next section.
 - `populations:` A list of populations found in your sample list to limit
   population analyses to. Might be useful if you want to perform individual
   analyses on some samples but not include them in any population level
-  analyses
+  analyses. Leave blank (`[]`) if you want population level analyses on all the
+  populations defined in your `samples.tsv` file.
 
 - `analyses:`
   - `mapping:`
     - `historical_only_collapsed:` Historical samples are expected to have
-      fragmented DNA. Overlapping (i.e. short) read pairs are collapsed in this
-      workflow, and while both overlapping and non-overlapping read pairs are
-      mapped for modern samples, setting this option to `true` will only map
-      the collapsed, overlapping read pairs for historical samples. This can
-      help avoid mapping contaminants, as longer fragments are likely from more
-      recent, non-endogenous DNA. However, in the event you want to map both,
-      you can set this to `false`. (`true`/`false`)
+      fragmented DNA. For this reason, overlapping (i.e. shorter, usually
+      <270bp) read pairs are collapsed in this workflow for historical samples.
+      Setting this option to `true` will only map only these collapsed reads,
+      and is recommended to target primarily endogenous content. However, in
+      the event you want to map both the collapsed and uncollapsed reads, you
+      can set this to `false`. (`true`/`false`)
     - `historical_collapsed_aligner:` Aligner used to map collapsed historical
       sample reads. `aln` is the recommended for this, but this is here in case
       you would like to select `mem` for this. Uncollapsed historical reads
       will be mapped with `mem` if `historical_only_collapsed` is set to
       `false`, regardless of what is put here. (`aln`/`mem`)
-  - `genmap:` Filter out sites with low mappability estimated by Genmap
-  (`true`/`false`)
-  - `repeatmasker:` (NOTE: Only one of the three options should be filled/true)
+  - `pileup-mappability:` Filter out sites with low 'pileup mappability', which
+    describes how uniquely fragments of a given size can map to the reference
+    (`true`/`false`)
+  - `repeatmasker:` (NOTE: Only one of the four options should be filled/true)
     - `bed:` Supply a path to a bed file that contains regions with repeats.
       This is for those who want to filter out repetitive content, but don't
       need to run Repeatmodeler or masker in the workflow because it has
@@ -235,10 +236,10 @@ settings for each analysis are set in the next section.
     section of the yaml. (`true`/`false`)
   - `dataset_missing_data:` A floating point value between 0 and 1. Sites with
     data for fewer than this proportion of individuals across the whole dataset
-    will be filtered out.
+    will be filtered out in all analyses using the filtered sites file.
   - `population_missing_data:` A floating point value between 0 and 1. Sites
     with data for fewer than this proportion of individuals in any population
-    will be filtered out for all populations.
+    will be filtered out in all populations using the filtered sites file.
   - `qualimap:` Perform Qualimap bamqc on bam files for general quality stats
     (`true`/`false`)
   - `damageprofiler:` Estimate post-mortem DNA damage on historical samples
@@ -450,6 +451,19 @@ or a pull request and I'll gladly put it in.
     - `maxdepth:` When calculating individual depth, sites with depth higher
       than this will be binned to this value. Should be fine for most to leave
       at `1000`. (integer, [docs](http://www.popgen.dk/angsd/index.php/Depth))
+    - `mindepthind:` Individuals with sequencing depth below this value at a
+      position will be treated as having no data at that position by ANGSD.
+      ANGSD defaults to 1 for this. Note that this can be separately set for
+      individual heterozygosity estimates with `mindepthind_heterozygosity`
+      below. (integer, `-setMinDepthInd` option in ANGSD)
+    - `minind_dataset:` Used to fill the `-minInd` option for any dataset wide
+      ANGSD outputs (like Beagles for PCA/Admix). Should be a floating point
+      value between 0 and 1 describing what proportion of the dataset must have
+      data at a site to include it in the output.
+    - `minind_pop:` Used to fill the `-minInd` option for any population level
+      ANGSD outputs (like SAFs or Beagles for ngsF-HMM). Should be a floating
+      point value between 0 and 1 describing what proportion of the population
+      must have data at a site to include it in the output.
     - `extra:` Additional options to pass to ANGSD during genotype likelihood
       calculation at all times. This is primarily useful for adding BAM input
       filters. Note that `--remove_bads` and `-only_proper_pairs` are enabled
@@ -489,6 +503,9 @@ or a pull request and I'll gladly put it in.
       PCAngsd, NGSadmix, ngsF-HMM, and NGSrelate. If you would like each tool
       to handle filtering for maf on its own you can set this to `-1`
       (disabled). (float, [docs](http://www.popgen.dk/angsd/index.php/Allele_Frequencies))
+    - `mindepthind_heterozygosity:` When estimating individual heterozygosity,
+      sites with sequencing depth lower than this value will be dropped.
+      (integer, `-setMinDepthInd` option in ANGSD)
   - `ngsld:` Settings for ngsLD ([docs](https://github.com/fgvieira/ngsLD))
     - `max_kb_dist_est-ld:` For the LD estimates generated when setting
       `estimate_ld: true` above, set the maximum distance between sites in kb

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ is generalizable and customizable through a single configuration file and uses
 a common workflow utilized by ANGSD users, so it is available for others to
 use, should it suit their needs.
 
-!!! question "Questions? Feature requests? Just ask!"
+??? question "Questions? Feature requests? Just ask!"
     I'm glad to answer questions on the [GitHub Issues](https://github.com/zjnolen/angsd-snakemake-pipeline/issues)
     page for the project, as well as take suggestions for features or
     improvements!

--- a/workflow/rules/0.2_ref_filt.smk
+++ b/workflow/rules/0.2_ref_filt.smk
@@ -571,7 +571,7 @@ rule angsd_missdata:
         angsd_container
     params:
         nind=lambda w: len(get_samples_from_pop(w.population)),
-        mindpind=config["params"]["angsd"]["missing_data_mindepthind"],
+        mindpind=config["params"]["angsd"]["mindepthind"],
         extra=config["params"]["angsd"]["extra"],
         mapQ=config["mapQ"],
         baseQ=config["baseQ"],

--- a/workflow/rules/3.1_safs.smk
+++ b/workflow/rules/3.1_safs.smk
@@ -44,6 +44,8 @@ rule angsd_doSaf_pop:
         extra_saf=config["params"]["angsd"]["extra_saf"],
         mapQ=config["mapQ"],
         baseQ=config["baseQ"],
+        minind=get_minind,
+        mininddp=config["params"]["angsd"]["mindepthind"],
         out=lambda w, output: os.path.splitext(output.arg)[0],
     resources:
         runtime=lambda wildcards, attempt: attempt * 180,
@@ -51,9 +53,10 @@ rule angsd_doSaf_pop:
     shell:
         """
         angsd -doSaf 1 -bam {input.bam} -GL {params.gl_model} -ref {input.ref} \
-            -nThreads {threads} {params.extra} -minMapQ {params.mapQ} \
+            -nThreads {threads} {params.extra} {params.minind} -minMapQ {params.mapQ} \
             -minQ {params.baseQ} -sites {input.sites} -anc {input.anc} \
-            {params.extra_saf} -rf {input.regions} -out {params.out} &> {log}
+            -setMinDepthInd {params.mininddp} {params.extra_saf} -rf {input.regions} \
+            -out {params.out} &> {log}
         """
 
 

--- a/workflow/rules/3.2_beagles.smk
+++ b/workflow/rules/3.2_beagles.smk
@@ -39,6 +39,8 @@ rule angsd_doGlf2:
         majmin=config["params"]["angsd"]["domajorminor"],
         counts=get_docounts,
         nind=lambda w: len(get_samples_from_pop(w.population)),
+        minind=get_minind,
+        mininddp=config["params"]["angsd"]["mindepthind"],
         out=lambda w, output: os.path.splitext(output.arg)[0],
     threads: lambda wildcards, attempt: attempt
     resources:
@@ -49,8 +51,8 @@ rule angsd_doGlf2:
             -doMajorMinor {params.majmin} -doMaf {params.maf} -minMaf {params.minmaf} \
             -SNP_pval {params.snp_pval} -nThreads {threads} {params.extra} \
             -minMapQ {params.mapQ} -minQ {params.baseQ} -sites {input.sites} \
-            -anc {input.anc} {params.extra_beagle} -rf {input.regions} \
-            {params.counts} -out {params.out} &> {log}
+            -anc {input.anc} {params.extra_beagle} -rf {input.regions} {params.minind} \
+            -setMinDepthInd {params.mininddp} {params.counts} -out {params.out} &> {log}
         """
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -610,6 +610,21 @@ def get_anc_ref(wildcards):
     }
 
 
+# Define if minimum individual filtering will happen in ANGSD, and set the
+# command line option
+def get_minind(wildcards):
+    pop = wildcards.population
+    if pop == "all":
+        minind = int(
+            len(get_samples_from_pop(pop)) * config["params"]["angsd"]["minind_dataset"]
+        )
+    else:
+        minind = int(
+            len(get_samples_from_pop(pop)) * config["params"]["angsd"]["minind_pop"]
+        )
+    return f"-minInd {minind}"
+
+
 # Determine if docounts is needed for beagle/maf calculation to keep it from
 # slowing things down when it is not. It is only needed if the major and minor
 # alleles are being inferred from counts (-doMajorMinor 2) or the minor allele


### PR DESCRIPTION
Instead of a missingness filter that is universal across all analyses using the filtered sites file, this allows missingness to be done per analysis as is usually done with the `-minInd` option in ANGSD. Either option (or both) can be enabled, and I will think about if the sites file style missingness filter has any reason to stick around with this option available.