### PR TITLE
fix: allow decimal values for subsampled depth targets

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,10 +59,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Set up conda environment and singularity
-      uses: mamba-org/setup-micromamba@v1
+      uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: environment.yaml
-        micromamba-version: '1.5.9-0'
     - name: Test workflow
       shell: bash -l {0}
       run: |

--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -75,7 +75,7 @@ analyses:
 
 #==================== Downsampling Configuration ======================#
 
-subsample_dp: [3, 2]
+subsample_dp: [0.99, 2]
 
 subsample_by: "sitefilt" # three options: unfilt, mapqbaseq, sitefilt; sitefilt recommended (subsamples bams to `subsample_dp` within filtered regions)
 redo_depth_filts: false # has no effect when `subsample_by` == "sitefilt"

--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -75,7 +75,7 @@ analyses:
 
 #==================== Downsampling Configuration ======================#
 
-subsample_dp: [0.99, 2]
+subsample_dp: [2.99, 2]
 
 subsample_by: "sitefilt" # three options: unfilt, mapqbaseq, sitefilt; sitefilt recommended (subsamples bams to `subsample_dp` within filtered regions)
 redo_depth_filts: false # has no effect when `subsample_by` == "sitefilt"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -57,7 +57,7 @@ wildcard_constraints:
         [i for i in samples.index.tolist()]
         + [i for i in samples.population.values.tolist()]
     ),
-    dp=".{0}|.dp[1-9][0-9]*",
+    dp=".{0}|[.]dp[0-9]+([.][0-9]+)?",
     chunk="[0-9]+",
     sites="|".join(filters),
 

--- a/workflow/rules/2.0_mapping.smk
+++ b/workflow/rules/2.0_mapping.smk
@@ -396,6 +396,7 @@ rule samtools_subsample:
     params:
         dp=lambda w: w.dp.replace(".dp", ""),
         seed=config["params"]["samtools"]["subsampling_seed"],
+        mapq=bam_subsample_mapq,
     resources:
         runtime=lambda wildcards, attempt: attempt * 720,
     shell:
@@ -406,7 +407,7 @@ rule samtools_subsample:
 
         if [ `awk 'BEGIN {{print ('$prop' <= 1.0)}}'` = 1 ]; then
             propdec=$(echo $prop | awk -F "." '{{print $2}}')
-            samtools view -h -F 4 -q 30 -@ {threads} -u {input.bam} |
+            samtools view -h -F 4 {params.mapq} -@ {threads} -u {input.bam} |
                 samtools view -h -s {params.seed}.${{propdec}} -@ {threads} -b \
                 > {output.bam} 2> {log}
             samtools index {output.bam} 2>> {log}

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -678,6 +678,16 @@ def depth_file(wildcards):
         return "results/datasets/{dataset}/qc/ind_depth/filtered/{dataset}.{ref}_{sample}_allsites-filts.depth.sum"
 
 
+# Determine if reads less than minimum mapping quality will be included in the
+# subsamled bams. Only include these if subsampling is done based on mapq/baseq
+# filtered depth or sites file filtered depth (which also filts by mapq/baseq)
+def bam_subsample_mapq(wildcards):
+    if config["subsample_by"] in ["mapqbaseq", "sitefilt"]:
+        mapq = config["mapQ"]
+        return f"-q {mapq}"
+    return ""
+
+
 # Choose to use an ancestral reference if present, otherwise use main reference
 def get_anc_ref(wildcards):
     if config["ancestral"]:


### PR DESCRIPTION
Fixes #63. Also makes sure that subsampling only uses reads passing mapping quality filter when relevant