### PR TITLE
Fix rules that combine sample outputs failing when dataset has a large number of samples

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -74,8 +74,8 @@ jobs:
         mkdir -p temp
         workdir=$(pwd -P)
         TMPDIR=$workdir/temp
-        snakemake --directory .test --configfile .test/config/config.yaml --config samples=config/samples_testSRA.tsv --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --use-singularity --default-resources mem_mb=1000 --until fastp_mergedout
-        snakemake --directory .test --configfile .test/config/config.yaml --use-conda --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --use-singularity --default-resources mem_mb=1000
+        snakemake --directory .test --configfile .test/config/config.yaml --config samples=config/samples_testSRA.tsv --sdm conda apptainer --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --default-resources mem_mb=1000 --until fastp_mergedout
+        snakemake --directory .test --configfile .test/config/config.yaml --sdm conda apptainer --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --default-resources mem_mb=1000
     - name: Test report
       shell: bash -l {0}
       run: |

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,3 +1,9 @@
+# This is a suggested environment for the workflow, but you can use your own
+# snakemake installation, a separate one for popglen is not required. Snakemake
+# v8 and v9 both are working and each rule will be run in its own environment,
+# so the environment used to run snakemake does not affect the outputs of the
+# workflow.
+
 name: popglen
 
 channels:
@@ -6,5 +12,5 @@ channels:
 
 dependencies:
   # core packages for workflow
-  - snakemake =8.25.0
+  - snakemake >=8.25
   - python =3.12

--- a/workflow/rules/2.1_sample_qc.smk
+++ b/workflow/rules/2.1_sample_qc.smk
@@ -308,17 +308,12 @@ rule merge_ind_depth:
     Combine depth summaries for all individuals
     """
     input:
-        depth=lambda w: expand(
-            "{{prefix}}{{dataset}}.{{ref}}_{sample}{{dp}}_{{group}}.depthSample",
-            sample=get_popfile_inds(w),
-        ),
-        summary=lambda w: expand(
+        lambda w: expand(
             "{{prefix}}{{dataset}}.{{ref}}_{sample}{{dp}}_{{group}}.depth.sum",
             sample=get_popfile_inds(w),
         ),
     output:
-        dep="{prefix}{dataset}.{ref}_{population}{dp}_{group}.depth",
-        sum="{prefix}{dataset}.{ref}_{population}{dp}_{group}.depth.sum",
+        "{prefix}{dataset}.{ref}_{population}{dp}_{group}.depth.sum",
     wildcard_constraints:
         population="all",
     log:
@@ -326,16 +321,17 @@ rule merge_ind_depth:
     benchmark:
         "benchmarks/merge_depth/{prefix}{dataset}.{ref}_{population}{dp}_{group}.log"
     container:
-        shell_container
+        pandas_container
     resources:
         runtime="15m",
-    shell:
-        """
-        (cat {input.depth} > {output.dep}
-        printf "sample\t{wildcards.group}.depth.mean\t{wildcards.group}.depth.stdev\n" \
-            > {output.sum}
-        cat {input.summary} >> {output.sum}) 2> {log}
-        """
+    params:
+        header=[
+            "sample",
+            "{group}.depth.mean",
+            "{group}.depth.stdev",
+        ],
+    script:
+        "../scripts/concat_files.py"
 
 
 rule combine_sample_qc:
@@ -514,7 +510,7 @@ rule merge_ibs_ref_bias:
             population=get_popfile_inds(w),
         ),
     output:
-        ibs=temp(
+        temp(
             "results/datasets/{dataset}/qc/ibs_refbias/{dataset}.{ref}_{population}{dp}_{filts}.refibs.merged.tsv"
         ),
     log:
@@ -522,16 +518,15 @@ rule merge_ibs_ref_bias:
     benchmark:
         "benchmarks/{dataset}/angsd/ibs_ref_bias/{dataset}.{ref}_{population}{dp}_{filts}_merge.log"
     container:
-        shell_container
+        pandas_container
     resources:
         runtime="15m",
     group:
         "combine_ibsrefbias"
-    shell:
-        r"""
-        printf "sample\tibs.to.ref\n" > {output}
-        cat {input} >> {output}
-        """
+    params:
+        header=["sample", "ibs.to.ref"],
+    script:
+        "../scripts/concat_files.py"
 
 
 rule plot_ibs_ref_bias:

--- a/workflow/rules/2.1_sample_qc.smk
+++ b/workflow/rules/2.1_sample_qc.smk
@@ -162,7 +162,7 @@ rule compile_endo_cont:
     shell:
         """
         (printf "sample\tperc.collapsed.map\tperc.uncollapsed.map\tperc.total.map\n" > {output}
-        cat {input} >> {output}) 2> {log}
+        echo {input} | xargs cat >> {output}) 2> {log}
         """
 
 

--- a/workflow/rules/2.1_sample_qc.smk
+++ b/workflow/rules/2.1_sample_qc.smk
@@ -156,14 +156,16 @@ rule compile_endo_cont:
     benchmark:
         "benchmarks/datasets/{dataset}/qc/endogenous_content/{dataset}.{ref}_{population}{dp}_compile-endocont.log"
     container:
-        shell_container
-    resources:
-        runtime="15m",
-    shell:
-        """
-        (printf "sample\tperc.collapsed.map\tperc.uncollapsed.map\tperc.total.map\n" > {output}
-        echo {input} | xargs cat >> {output}) 2> {log}
-        """
+        pandas_container
+    params:
+        header=[
+            "sample",
+            "perc.collapsed.map",
+            "perc.uncollapsed.map",
+            "perc.total.map",
+        ],
+    script:
+        "../scripts/concat_files.py"
 
 
 rule ind_unfiltered_depth:

--- a/workflow/rules/3.0_genotype_likelihoods.smk
+++ b/workflow/rules/3.0_genotype_likelihoods.smk
@@ -18,18 +18,13 @@ rule angsd_makeBamlist:
     log:
         "logs/datasets/{dataset}/bamlists/{dataset}.{ref}_{population}{dp}.log",
     container:
-        shell_container
+        pandas_container
     params:
         sampord=lambda w, input: f"{input.bams}",
     resources:
         runtime="15m",
-    shell:
-        """
-        (
-        echo "BAM order: {params.sampord}" > {log}
-        readlink -f {input.bams} > {output} 2>> {log}
-        truncate -s -1 {output}) 2>> {log}
-        """
+    script:
+        "../scripts/make_bamlist.py"
 
 
 rule popfile:

--- a/workflow/rules/5.0_relatedness.smk
+++ b/workflow/rules/5.0_relatedness.smk
@@ -46,16 +46,15 @@ rule compile_kinship_stats_sfs:
     benchmark:
         "benchmarks/{dataset}/kinship/ibsrelate_sfs/{dataset}.{ref}_all{dp}_{sites}-filts_compile-stats.log"
     container:
-        shell_container
+        pandas_container
     resources:
         runtime="15m",
     group:
         "sfs-ibsrelate"
-    shell:
-        """
-        (printf "ind1\tind2\tR0\tR1\tKING\n" > {output}
-        cat {input} >> {output}) 2> {log}
-        """
+    params:
+        header=["ind1", "ind2", "R0", "R1", "KING"],
+    script:
+        "../scripts/concat_files.py"
 
 
 rule doGlf1_ibsrelate:

--- a/workflow/rules/7.2_fst.smk
+++ b/workflow/rules/7.2_fst.smk
@@ -113,23 +113,22 @@ rule aggregate_fst_global:
     input:
         unpack(get_fst),
     output:
-        glob="results/datasets/{dataset}/analyses/fst/{dataset}.{ref}_{unit}pairs{dp}_{sites}-filts.fst.{scale}.tsv",
+        "results/datasets/{dataset}/analyses/fst/{dataset}.{ref}_{unit}pairs{dp}_{sites}-filts.fst.{scale}.tsv",
     log:
         "logs/{dataset}/realSFS/fst/aggregate/{dataset}.{ref}_{unit}pairs{dp}_{sites}-filts.{scale}.log",
     benchmark:
         "benchmarks/{dataset}/realSFS/fst/aggregate/{dataset}.{ref}_{unit}pairs{dp}_{sites}-filts.{scale}.log"
     container:
-        shell_container
+        pandas_container
     wildcard_constraints:
         unit="ind|pop",
         scale="global",
     resources:
         runtime="1h",
-    shell:
-        """
-        (printf "pop1\tpop2\tunweight.fst\tweight.fst\n" > {output.glob}
-        cat {input} >> {output.glob}) 2> {log}
-        """
+    params:
+        header=["pop1", "pop2", "unweight.fst", "weight.fst"],
+    script:
+        "../scripts/concat_files.py"
 
 
 rule aggregate_fst_window:
@@ -139,26 +138,31 @@ rule aggregate_fst_window:
     input:
         unpack(get_fst),
     output:
-        window="results/datasets/{dataset}/analyses/fst/{dataset}.{ref}_{unit}pairs{dp}_{sites}-filts.fst.{scale}_{win}_{step}.tsv",
+        "results/datasets/{dataset}/analyses/fst/{dataset}.{ref}_{unit}pairs{dp}_{sites}-filts.fst.{scale}_{win}_{step}.tsv",
     log:
         "logs/{dataset}/realSFS/fst/aggregate/{dataset}.{ref}_{unit}pairs{dp}_{sites}-filts.{scale}_{win}_{step}.log",
     benchmark:
         "benchmarks/{dataset}/realSFS/fst/aggregate/{dataset}.{ref}_{unit}pairs{dp}_{sites}-filts.{scale}_{win}_{step}.log"
     container:
-        shell_container
+        pandas_container
     wildcard_constraints:
         unit="ind|pop",
         scale="window",
     resources:
         runtime="1h",
-    shell:
-        """
-        (printf "pop1\tpop2\twindow\tchr\twindow_center\tNsites\tweight.fst\n" \
-            > {output.window}
-        for i in {input}; do
-            tail -n +2 $i >> {output.window}
-        done) 2> {log}
-        """
+    params:
+        header=[
+            "pop1",
+            "pop2",
+            "window",
+            "chr",
+            "window_center",
+            "Nsites",
+            "weight.fst",
+        ],
+        input_has_header=True,
+    script:
+        "../scripts/concat_files.py"
 
 
 rule plot_fst:

--- a/workflow/scripts/concat_files.py
+++ b/workflow/scripts/concat_files.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+# Python script to concatenate multiple files and optionally add a header.
+# `inputs` is a list of files to concatenate (will be treated as tab-separated
+# files without header), `output` is the concatenated output file (will be made
+# as tab separated with header), and `header` is a list of column names to add
+# as a header (or set to false to not add a header to the output, set to false
+# automatically if the rule calling this script has no header param).
+
+inputs = snakemake.input
+output = snakemake.output[0]
+if hasattr(snakemake.params, "header"):
+    header = snakemake.params.header
+else:
+    header = False
+
+df = pd.concat(
+    [pd.read_csv(f, sep="\t", dtype=str, header=None) for f in inputs],
+    ignore_index=True,
+)
+
+df.to_csv(output, sep="\t", index=False, header=header)

--- a/workflow/scripts/concat_files.py
+++ b/workflow/scripts/concat_files.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import sys
 
 # Python script to concatenate multiple files and optionally add a header.
 # `inputs` is a list of files to concatenate (will be treated as tab-separated
@@ -7,15 +8,30 @@ import pandas as pd
 # as a header (or set to false to not add a header to the output, set to false
 # automatically if the rule calling this script has no header param).
 
+sys.stderr = open(snakemake.log[0], "w") if snakemake.log else sys.stderr
+
 inputs = snakemake.input
 output = snakemake.output[0]
+
+# Check if snakemake rule has a header to use in the params, if not, no header
+# will be output, even if it exists in the input files.
 if hasattr(snakemake.params, "header"):
     header = snakemake.params.header
 else:
     header = False
 
+# Check if snakemake rule specifies input files already have header. If so, skip
+# the first line of each input.
+if hasattr(snakemake.params, "input_has_header") and snakemake.params.input_has_header:
+    skiprows = 1
+else:
+    skiprows = None
+
 df = pd.concat(
-    [pd.read_csv(f, sep="\t", dtype=str, header=None) for f in inputs],
+    [
+        pd.read_csv(f, sep="\t", dtype=str, header=None, skiprows=skiprows)
+        for f in inputs
+    ],
     ignore_index=True,
 )
 

--- a/workflow/scripts/make_bamlist.py
+++ b/workflow/scripts/make_bamlist.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+# Prepares a bamlist for use as input to ANGSD. This is a list of bam files, one
+# per line given as the absolute path. There is no newline at the end of the
+# file. These concerns may no longer be present in the current version of ANGSD,
+# but are maintained in this script.
+
+sys.stderr = open(snakemake.log[0], "w") if snakemake.log else sys.stderr
+
+inputs = snakemake.input.bams
+bamlist = snakemake.output[0]
+
+print(f"BAM order: {snakemake.params.sampord}", file=sys.stderr)
+
+abs_paths = "\n".join([os.path.realpath(b) for b in inputs])
+
+with open(bamlist, "w") as f:
+    f.write(abs_paths)


### PR DESCRIPTION
Fixes #72. I think most of these errors are from cat receiving more arguments than it can handle. Trying to fix it by using echo and passing the output to xargs, which seems to work in the current shell container.