### PR TITLE
Fix: Fix ngsF-HMM failing in GH Actions (action configuration problem, works fine otherwise)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,9 +71,8 @@ jobs:
         sudo apt update
         sudo apt install -y apptainer-suid
         conda config --set channel_priority strict
-        mkdir -p temp
-        workdir=$(pwd -P)
-        export TMPDIR=$workdir/temp
+        mkdir -p .test/temp
+        export TMPDIR=$PWD/.test/temp
         snakemake --directory .test --configfile .test/config/config.yaml --config samples=config/samples_testSRA.tsv --sdm conda apptainer --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --default-resources mem_mb=1000 --until fastp_mergedout
         snakemake --directory .test --configfile .test/config/config.yaml --sdm conda apptainer --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --default-resources mem_mb=1000
     - name: Test report

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,10 +71,8 @@ jobs:
         sudo apt update
         sudo apt install -y apptainer-suid
         conda config --set channel_priority strict
-        mkdir -p .test/temp
-        export TMPDIR=$PWD/.test/temp
-        snakemake --directory .test --configfile .test/config/config.yaml --config samples=config/samples_testSRA.tsv --sdm conda apptainer --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --default-resources mem_mb=1000 --until fastp_mergedout
-        snakemake --directory .test --configfile .test/config/config.yaml --sdm conda apptainer --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --default-resources mem_mb=1000
+        snakemake --apptainer-args '-B /tmp' --directory .test --configfile .test/config/config.yaml --config samples=config/samples_testSRA.tsv --sdm conda apptainer --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --default-resources mem_mb=1000 --until fastp_mergedout
+        snakemake --apptainer-args '-B /tmp' --directory .test --configfile .test/config/config.yaml --sdm conda apptainer --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --default-resources mem_mb=1000
     - name: Test report
       shell: bash -l {0}
       run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,7 +73,7 @@ jobs:
         conda config --set channel_priority strict
         mkdir -p temp
         workdir=$(pwd -P)
-        TMPDIR=$workdir/temp
+        export TMPDIR=$workdir/temp
         snakemake --directory .test --configfile .test/config/config.yaml --config samples=config/samples_testSRA.tsv --sdm conda apptainer --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --default-resources mem_mb=1000 --until fastp_mergedout
         snakemake --directory .test --configfile .test/config/config.yaml --sdm conda apptainer --show-failed-logs --cores 2 --conda-cleanup-pkgs cache --default-resources mem_mb=1000
     - name: Test report


### PR DESCRIPTION
ngsF-HMM consistently fails in GitHub actions lately, but hasn't changed. Potentially an issue with it and the test data, but the test data runs fine with it on all the machines I've tested it on outside the GH runners. This pull request is for troubleshooting and maybe fixing if there is such a fix.