### PR TITLE
Minor fixes for qualimap and job resources

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,11 +12,11 @@ chunk_size: 50000000
 
 reference:
   name: "ref-name" 
-  fasta: "path/to/ref.fa"
-  mito: ["mitochondrion"]
-  sex-linked: ["Z"]
+  fasta: ".test/data/ref/testref.fa"
+  mito: []
+  sex-linked: []
   exclude: []
-  min_size: 1000000
+  min_size:
 
 ancestral:
 
@@ -40,37 +40,37 @@ analyses:
   repeatmasker:
     bed:
     local_lib:
-    build_lib:
-  extreme_depth:
+    build_lib: true
+  extreme_depth: true
   dataset_missing_data:
   population_missing_data:
   # quality control
   qualimap:
-  ibs_ref_bias:
+  ibs_ref_bias: true
   damageprofiler:
   mapdamage_rescale:
   # population genomic analyses
   estimate_ld:
   ld_decay:
-  pca_pcangsd:
-  admix_ngsadmix:
+  pca_pcangsd: true
+  admix_ngsadmix: true
   relatedness:
     ibsrelate_ibs:
     ibsrelate_sfs:
-    ngsrelate_ibsrelate-only:
+    ngsrelate_ibsrelate-only: true
     ngsrelate_freqbased:
-  1dsfs:
+  1dsfs: true
   1dsfs_boot:
-  2dsfs:
+  2dsfs: true
   2dsfs_boot:
-  thetas_angsd:
-  heterozygosity_angsd:
+  thetas_angsd: true
+  heterozygosity_angsd: true
   fst_angsd:
-    populations:
+    populations: true
     individuals:
-  inbreeding_ngsf-hmm:
-  ibs_matrix:
-  pop_allele_freqs:
+  inbreeding_ngsf-hmm: true
+  ibs_matrix: true
+  pop_allele_freqs: true
 
 #==================== Downsampling Configuration ======================#
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -62,6 +62,4 @@ set-resources:
 
 You can also use the term 'attempt' in these definitions, which allow you to
 scale the resources with the number of attempts a rule has made, automatically
-increasing threads, runtime, or memory with each attempt. This is already done
-for several rules in the config, largely to automatically request more memory
-due to OOM errors.
+increasing threads, runtime, or memory with each attempt.

--- a/profiles/default/config.yaml
+++ b/profiles/default/config.yaml
@@ -21,8 +21,8 @@ set-threads:
   smallscaff_bed: 1
   sexlink_bed: 1
   ## Mappability filtering
-  genmap_index: "attempt"
-  genmap_map: "attempt"
+  genmap_index: 1
+  genmap_map: 1
   windowgen: 1
   pileup_mappability: 1
   genmap_filt_bed: 1
@@ -32,37 +32,37 @@ set-threads:
   repeatmasker: 5
   repeat_sum: 1
   ## Depth filtering
-  angsd_depth: "attempt * 2"
+  angsd_depth: 1
   combine_depths: 1
   summarize_depths: 1
-  depth_bed: "attempt"
+  depth_bed: 1
   ## Site-based missing data filtering
-  angsd_missdata: "attempt * 2"
+  angsd_missdata: 1
   missdata_bed: 1
   ## Generate combined filter files
-  combine_beds: "attempt * 2"
-  user_sites: "attempt * 2"
+  combine_beds: 1
+  user_sites: 1
   filter_summary_table: 1
   # Raw sequencing data processing
   ncbi_download: 6
-  fastp_mergedout: "attempt * 2"
-  fastp_pairedout: "attempt * 2"
+  fastp_mergedout: 2
+  fastp_pairedout: 2
   fastp_multiqc: 1
   # Mapping
-  bwa_aln_merged: 20
-  bwa_samse_merged: "attempt"
-  bwa_mem_paired: "attempt * 10"
-  bwa_mem_merged: "attempt * 10"
-  samtools_merge_collapsed_libs: "attempt * 4"
-  samtools_merge_paired_units: "attempt * 4"
-  mark_duplicates: "attempt * 4"
-  dedup_merged: "attempt * 2"
-  samtools_merge_dedup: "attempt * 4"
-  realignertargetcreator: "attempt * 2"
-  indelrealigner: "attempt * 4"
-  bam_clipoverlap: "attempt * 2"
+  bwa_aln_merged: 12
+  bwa_samse_merged: 1
+  bwa_mem_paired: 12
+  bwa_mem_merged: 12
+  samtools_merge_collapsed_libs: 2
+  samtools_merge_paired_units: 2
+  mark_duplicates: 4
+  dedup_merged: 2
+  samtools_merge_dedup: 2
+  realignertargetcreator: 2
+  indelrealigner: 8
+  bam_clipoverlap: 2
   symlink_userbams: 1
-  bam_clipoverlap_userbams: "attempt * 2"
+  bam_clipoverlap_userbams: 2
   samtools_index: 1
   symlink_bams: 1
   samtools_subsample: 1
@@ -73,21 +73,21 @@ set-threads:
   qualimap_multiqc: 1
   endo_cont: 1
   compile_endo_cont: 1
-  ind_unfiltered_depth: "attempt"
-  ind_mapQ_baseQ_depth: "attempt"
-  ind_filtered_depth: "attempt"
+  ind_unfiltered_depth: 1
+  ind_mapQ_baseQ_depth: 1
+  ind_filtered_depth: 1
   summarize_ind_depth: 1
   merge_ind_depth: 1
   combine_sample_qc: 1
   sample_qc_summary: 1
-  ibs_ref_bias_nofilts: "attempt"
-  ibs_ref_bias_filts: "attempt"
+  ibs_ref_bias_nofilts: 1
+  ibs_ref_bias_filts: 1
   merge_ibs_ref_bias: 1
   plot_ibs_ref_bias: 1
   ibs_ref_bias_table_html: 1
   # Post-mortem DNA damage
-  damageprofiler: "attempt"
-  damageprofiler_userbam: "attempt"
+  damageprofiler: 1
+  damageprofiler_userbam: 1
   mapDamage2_rescaling: 1
   dna_damage_multiqc: 1
   # ANGSD input file preparation
@@ -95,48 +95,48 @@ set-threads:
   popfile: 1
   angsd_sites_index: 1
   # ANGSD -doSaf
-  angsd_doSaf_pop: "attempt * 2"
+  angsd_doSaf_pop: 1
   realSFS_catsaf: 1
   angsd_doSaf_sample: 1
   # ANGSD -doGlf2/-doMaf (Beagle/MAFs)
-  angsd_doGlf2: "attempt"
+  angsd_doGlf2: 1
   merge_beagle: 1
   merge_maf: 1
   snpset: 1
   link_mafs: 1
-  angsd_doMaf: "attempt"
+  angsd_doMaf: 1
   # Linkage disequilibrium (LD) calculation, decay, and pruning
-  ngsLD_estLD: "attempt"
+  ngsLD_estLD: 4
   combine_LD_files: 1
   ngsLD_prune_sites: 4
-  prune_chunk_beagle: "attempt"
+  prune_chunk_beagle: 1
   merge_pruned_beagles: 1
   combine_LDdecay_files: 1
-  fit_LD_decay: "attempt"
+  fit_LD_decay: 1
   # Kinship/relatedness
   est_kinship_stats_sfs: 1
   compile_kinship_stats_sfs: 1
-  doGlf1_ibsrelate: "attempt * 2"
-  ibsrelate: "attempt * 10" # This is due to high RAM usage in cluster environments where RAM is tied to threads. If it is not in yours, you can set the mem_mb resource for this below and lower this
+  doGlf1_ibsrelate: 1
+  ibsrelate: 1
   est_kinship_stats_ibs: 1
   kinship_table_html: 1
-  ngsrelate_ibsrelate_only: "attempt * 4"
-  ngsrelate_freqbased: "attempt * 4"
+  ngsrelate_ibsrelate_only: 4
+  ngsrelate_freqbased: 4
   ngsrelate_freqbased_merge: 1
   ngsrelate_summary: 1
   # PCA/Admixture
   remove_excl_pca_admix: 1
-  pca_pcangsd: "attempt"
+  pca_pcangsd: 2
   plot_pca: 1
   ngsAdmix: 4
   plot_admix: 1
   evalAdmix: 1
   plot_evalAdmix: 1
   # Site frequency spectra (SFS)
-  realSFS_1dSFS: "attempt * 2"
-  realSFS_1dSFS_bootstrap: "attempt * 2"
-  realSFS_2dSFS: "attempt * 2"
-  realSFS_2dSFS_bootstrap: "attempt * 2"
+  realSFS_1dSFS: 4
+  realSFS_1dSFS_bootstrap: 4
+  realSFS_2dSFS: 4
+  realSFS_2dSFS_bootstrap: 4
   # Thetas (nucleotide diversity, Watterson's theta, Tajima's D)
   realSFS_saf2theta: 1
   thetaStat: 1
@@ -184,7 +184,7 @@ set-resources:
   genmap_index:
     runtime: "1h"
   genmap_map:
-    runtime: "attempt * 360"
+    runtime: "6h"
   windowgen:
     runtime: "12h"
   pileup_mappability:
@@ -195,23 +195,23 @@ set-resources:
   repeat_builddatabase:
     runtime: "1h"
   repeatmodeler:
-    runtime: "7d"
+    runtime: "3d" # potentially very long running, so consider setting to your cluster limit minus 1h (for grouping with database building)
   repeatmasker:
     runtime: "12h"
   repeat_sum:
     runtime: "1h"
   ## Depth filtering
   angsd_depth:
-    runtime: "attempt * 720"
+    runtime: "12h"
   combine_depths:
     runtime: "10m"
   summarize_depths:
-    runtime: "15m"
+    runtime: "30m"
   depth_bed:
-    runtime: "1h"
+    runtime: "1d"
   ## Site-based missing data filtering
   angsd_missdata:
-    runtime: "attempt * 360"
+    runtime: "6h"
   missdata_bed:
     runtime: "1h"
   ## Generate combined filter files
@@ -232,37 +232,37 @@ set-resources:
     runtime: "1h"
   # Mapping
   bwa_aln_merged:
-    runtime: "7d"
+    runtime: "3d"
   bwa_samse_merged:
     runtime: "6h"
   bwa_mem_paired:
-    runtime: "attempt * 2880"
+    runtime: "3d"
   bwa_mem_merged:
-    runtime: "attempt * 2880"
+    runtime: "3d"
   samtools_merge_collapsed_libs:
-    runtime: "attempt * 720"
+    runtime: "12h"
   samtools_merge_paired_units:
-    runtime: "attempt * 720"
+    runtime: "12h"
   mark_duplicates:
-    runtime: "attempt * 1440"
+    runtime: "12h"
   samtools_merge_dedup:
-    runtime: "attempt * 1440"
+    runtime: "12h"
   realignertargetcreator:
-    runtime: "attempt * 720"
+    runtime: "12h"
   indelrealigner:
-    runtime: "attempt * 1440"
+    runtime: "1d"
   bam_clipoverlap:
-    runtime: "attempt * 720"
+    runtime: "12h"
   symlink_userbams:
     runtime: "5m"
   bam_clipoverlap_userbams:
-    runtime: "attempt * 720"
+    runtime: "12h"
   samtools_index:
     runtime: "1h"
   symlink_bams:
     runtime: "5m"
   samtools_subsample:
-    runtime: "attempt * 720"
+    runtime: "12h"
   # Sample QC
   samtools_flagstat:
     runtime: "1h"
@@ -277,11 +277,11 @@ set-resources:
   compile_endo_cont:
     runtime: "15m"
   ind_unfiltered_depth:
-    runtime: "attempt * 120"
+    runtime: "2h"
   ind_mapQ_baseQ_depth:
-    runtime: "attempt * 120"
+    runtime: "2h"
   ind_filtered_depth:
-    runtime: "attempt * 60"
+    runtime: "1h"
   summarize_ind_depth:
     runtime: "15m"
   merge_ind_depth:
@@ -291,9 +291,9 @@ set-resources:
   sample_qc_summary:
     runtime: "15m"
   ibs_ref_bias_nofilts:
-    runtime: "attempt * 720"
+    runtime: "12h"
   ibs_ref_bias_filts:
-    runtime: "attempt * 720"
+    runtime: "12h"
   merge_ibs_ref_bias:
     runtime: "15m"
   plot_ibs_ref_bias:
@@ -301,9 +301,9 @@ set-resources:
   ibs_ref_bias_table_html:
     runtime: "15m"
   damageprofiler:
-    runtime: "attempt * 60"
+    runtime: "1h"
   damageprofiler_userbam:
-    runtime: "attempt * 60"
+    runtime: "1h"
   mapDamage2_rescaling:
     runtime: "1d"
   dna_damage_multiqc:
@@ -317,14 +317,14 @@ set-resources:
     runtime: "1h"
   # ANGSD -doSaf
   angsd_doSaf_pop:
-    runtime: "attempt * 180"
+    runtime: "6h"
   realSFS_catsaf:
-    runtime: "attempt * 60"
+    runtime: "1h"
   angsd_doSaf_sample:
     runtime: "120m"
   # ANGSD -doGlf2/-doMaf (Beagle/MAFs)
   angsd_doGlf2:
-    runtime: "attempt * 720"
+    runtime: "12h"
   merge_beagle:
     runtime: "4h"
   merge_maf:
@@ -334,10 +334,10 @@ set-resources:
   link_mafs:
     runtime: "1h"
   angsd_doMaf:
-    runtime: "attempt * 720"
+    runtime: "12h"
   # Linkage disequilibrium (LD) calculation, decay, and pruning
   ngsLD_estLD:
-    runtime: "attempt * 720"
+    runtime: "12h"
   combine_LD_files:
     runtime: "1h"
   ngsLD_prune_sites:
@@ -356,17 +356,17 @@ set-resources:
   compile_kinship_stats_sfs:
     runtime: "15m"
   doGlf1_ibsrelate:
-    runtime: "attempt * 360"
+    runtime: "6h"
   ibsrelate:
-    runtime: "7d"
+    runtime: "3d"
   est_kinship_stats_ibs:
     runtime: "1h"
   kinship_table_html:
     runtime: "15m"
   ngsrelate_ibsrelate_only:
-    runtime: "attempt * 360"
+    runtime: "6h"
   ngsrelate_freqbased:
-    runtime: "attempt * 360"
+    runtime: "6h"
   ngsrelate_freqbased_merge:
     runtime: "15m"
   ngsrelate_summary:
@@ -379,7 +379,7 @@ set-resources:
   plot_pca:
     runtime: "1h"
   ngsAdmix:
-    runtime: "7d"
+    runtime: "3d"
   plot_admix:
     runtime: "1h"
   evalAdmix:
@@ -388,13 +388,13 @@ set-resources:
     runtime: "15m"
   # Site frequency spectra (SFS)
   realSFS_1dSFS:
-    runtime: "attempt * 720"
+    runtime: "1d"
   realSFS_1dSFS_bootstrap:
-    runtime: "7d"
+    runtime: "3d"
   realSFS_2dSFS:
-    runtime: "attempt * 720"
+    runtime: "12h"
   realSFS_2dSFS_bootstrap:
-    runtime: "7d"
+    runtime: "3d"
   # Thetas (nucleotide diversity, Watterson's theta, Tajima's D)
   realSFS_saf2theta:
     runtime: "4h"

--- a/workflow/rules/0.1_ref_prep.smk
+++ b/workflow/rules/0.1_ref_prep.smk
@@ -64,7 +64,7 @@ rule bwa_index:
     log:
         "logs/ref/bwa_index/{ref}.log",
     resources:
-        runtime="120m",
+        runtime="2h",
     benchmark:
         "benchmarks/ref/bwa_index/{ref}.log"
     wrapper:
@@ -86,7 +86,7 @@ rule samtools_faidx:
     benchmark:
         "benchmarks/ref/samtools_faidx/{ref}/{prefix}.log"
     resources:
-        runtime="10m",
+        runtime="1h",
     shell:
         """
         samtools faidx {input} 2> {log}

--- a/workflow/rules/0.1_ref_prep.smk
+++ b/workflow/rules/0.1_ref_prep.smk
@@ -5,7 +5,6 @@
 
 localrules:
     link_ref,
-    link_anc_ref,
     samtools_faidx,
     ref_chunking,
 
@@ -40,6 +39,7 @@ if config["ancestral"]:
             "logs/ref/link_ref/{ref}.anc.log",
         container:
             shell_container
+        localrule: True
         resources:
             runtime="5m",
         shell:

--- a/workflow/rules/0.2_ref_filt.smk
+++ b/workflow/rules/0.2_ref_filt.smk
@@ -151,9 +151,8 @@ rule genmap_index:
         "benchmarks/ref/genmap/index/{ref}.log"
     container:
         genmap_container
-    threads: lambda wildcards, attempt: attempt
     resources:
-        runtime="60m",
+        runtime="1h",
     group:
         "genmap"
     shell:
@@ -181,9 +180,8 @@ rule genmap_map:
         genmap_container
     params:
         out=lambda w, output: os.path.splitext(output.bed)[0],
-    threads: lambda wildcards, attempt: attempt
     resources:
-        runtime=lambda wildcards, attempt: attempt * 360,
+        runtime="6h",
     group:
         "genmap"
     shell:
@@ -335,7 +333,7 @@ rule repeatmodeler:
         ref="{ref}",
     threads: 10
     resources:
-        runtime="7d",
+        runtime="3d",
     shadow:
         "minimal"
     group:
@@ -362,7 +360,7 @@ rule repeatmasker:
         out=lambda w, output: os.path.dirname(output.gff),
     threads: 5
     resources:
-        runtime="720m",
+        runtime="12h",
     shadow:
         "shallow"
     group:
@@ -438,9 +436,8 @@ if config["analyses"]["extreme_depth"]:
             mapQ=config["mapQ"],
             baseQ=config["baseQ"],
             out=lambda w, output: os.path.splitext(output.arg)[0],
-        threads: lambda wildcards, attempt: attempt * 2
         resources:
-            runtime=lambda wildcards, attempt: attempt * 720,
+            runtime="12h",
         shell:
             """
             (nInd=$(cat {input.bamlist} | wc -l | awk '{{print $1+1}}')
@@ -504,9 +501,8 @@ if config["analyses"]["extreme_depth"]:
             lower=config["params"]["extreme_depth_filt"]["bounds"][0],
             upper=config["params"]["extreme_depth_filt"]["bounds"][1],
             method=config["params"]["extreme_depth_filt"]["method"],
-        threads: lambda wildcards, attempt: attempt * 2
         resources:
-            runtime="1h",
+            runtime="30m",
         group:
             "depth_bed"
         script:
@@ -531,9 +527,8 @@ if config["analyses"]["extreme_depth"]:
             "benchmarks/{dataset}/filters/depth/bed/{dataset}.{ref}_{population}{dp}.log"
         container:
             bedtools_container
-        threads: lambda wildcards, attempt: attempt
         resources:
-            runtime="1h",
+            runtime="1d",
         group:
             "depth_bed"
         shell:
@@ -588,9 +583,8 @@ rule angsd_missdata:
         mapQ=config["mapQ"],
         baseQ=config["baseQ"],
         out=lambda w, output: os.path.splitext(output.arg)[0],
-    threads: lambda wildcards, attempt: attempt * 2
     resources:
-        runtime=lambda wildcards, attempt: attempt * 360,
+        runtime="6h",
     shell:
         """
         (minInd=$(echo {params.nind} \
@@ -668,7 +662,6 @@ rule combine_beds:
         "benchmarks/{dataset}/filters/combine/{dataset}.{ref}{dp}_combine_beds.log"
     container:
         bedtools_container
-    threads: lambda wildcards, attempt: attempt * 2
     resources:
         runtime="4h",
     shell:
@@ -725,7 +718,6 @@ rule user_sites:
         "benchmarks/{dataset}/filters/user_sites/{dataset}.{ref}{dp}_{sites}-filt.log"
     container:
         bedtools_container
-    threads: lambda wildcards, attempt: attempt * 2
     resources:
         runtime="4h",
     shell:

--- a/workflow/rules/1.0_preprocessing.smk
+++ b/workflow/rules/1.0_preprocessing.smk
@@ -52,9 +52,9 @@ rule fastp_mergedout:
     params:
         extra=lambda w: config["params"]["fastp"]["extra"]
         + f" --merge --overlap_len_require {config['params']['fastp']['min_overlap_hist']}",
-    threads: lambda wildcards, attempt: attempt * 2
+    threads: 2
     resources:
-        runtime=lambda wildcards, attempt: attempt * 480,
+        runtime="8h",
     wrapper:
         "v4.0.0/bio/fastp"
 
@@ -88,9 +88,9 @@ rule fastp_pairedout:
         "benchmarks/preprocessing/fastp/{sample}_{unit}_{lib}.paired.log"
     params:
         extra=lambda w: config["params"]["fastp"]["extra"],
-    threads: lambda wildcards, attempt: attempt * 2
+    threads: 2
     resources:
-        runtime=lambda wildcards, attempt: attempt * 480,
+        runtime="8h",
     wrapper:
         "v4.0.0/bio/fastp"
 

--- a/workflow/rules/2.0_mapping.smk
+++ b/workflow/rules/2.0_mapping.smk
@@ -21,9 +21,9 @@ rule bwa_aln_merged:
         "benchmarks/mapping/bwa_aln/{sample}_{unit}_{lib}.{ref}.merged.log"
     params:
         extra=config["params"]["bwa_aln"]["extra"],
-    threads: 20
+    threads: 12
     resources:
-        runtime="7d",
+        runtime="3d",
     wrapper:
         "v4.0.0/bio/bwa/aln"
 
@@ -46,7 +46,6 @@ rule bwa_samse_merged:
         extra=lambda w: f"-r {get_read_group(w)}",
         sort="samtools",
         sort_order="coordinate",
-    threads: lambda wildcards, attempt: attempt
     resources:
         runtime="6h",
     wrapper:
@@ -73,9 +72,9 @@ rule bwa_mem_paired:
     params:
         extra=lambda w: f"-R {get_read_group(w)}",
         sorting="samtools",
-    threads: lambda wildcards, attempt: attempt * 10
+    threads: 12
     resources:
-        runtime=lambda wildcards, attempt: attempt * 2880,
+        runtime="3d",
     wrapper:
         "v4.0.0/bio/bwa/mem"
 
@@ -95,9 +94,9 @@ rule bwa_mem_merged:
     params:
         extra=lambda w: f"-R {get_read_group(w)}",
         sorting="samtools",
-    threads: lambda wildcards, attempt: attempt * 10
+    threads: 12
     resources:
-        runtime=lambda wildcards, attempt: attempt * 2880,
+        runtime="3d",
     wrapper:
         "v4.0.0/bio/bwa/mem"
 
@@ -111,9 +110,9 @@ rule samtools_merge_collapsed_libs:
         "logs/mapping/samtools/merge/{sample}_{lib}.{ref}.merged.log",
     benchmark:
         "benchmarks/mapping/samtools/merge/{sample}_{lib}.{ref}.merged.log"
-    threads: lambda wildcards, attempt: attempt * 4
+    threads: 2
     resources:
-        runtime=lambda wildcards, attempt: attempt * 720,
+        runtime="12h",
     wrapper:
         "v4.0.0/bio/samtools/merge"
 
@@ -127,9 +126,9 @@ rule samtools_merge_paired_units:
         "logs/mapping/samtools/merge/{sample}.{ref}.paired.log",
     benchmark:
         "benchmarks/mapping/samtools/{sample}.{ref}.paired.log"
-    threads: lambda wildcards, attempt: attempt * 4
+    threads: 2
     resources:
-        runtime=lambda wildcards, attempt: attempt * 720,
+        runtime="12h",
     wrapper:
         "v4.0.0/bio/samtools/merge"
 
@@ -149,9 +148,9 @@ rule mark_duplicates:
         extra=config["params"]["picard"]["MarkDuplicates"],
     shadow:
         "minimal"
-    threads: lambda wildcards, attempt: attempt * 4
+    threads: 4
     resources:
-        runtime=lambda wildcards, attempt: attempt * 1440,
+        runtime="12h",
     wrapper:
         "v4.0.0/bio/picard/markduplicates"
 
@@ -175,11 +174,11 @@ rule dedup_merged:
         "../envs/dedup.yaml"
     shadow:
         "minimal"
-    threads: lambda wildcards, attempt: attempt * 2
+    threads: 2
     params:
         outdir=lambda w, output: os.path.dirname(output.bamfin),
     resources:
-        runtime=lambda wildcards, attempt: attempt * 1440,
+        runtime="12h",
     shell:
         """
         (dedup -i {input} -m -u -o {params.outdir}
@@ -206,9 +205,9 @@ rule samtools_merge_dedup:
         "logs/mapping/samtools/merge/{sample}.{ref}.rmdup.log",
     benchmark:
         "benchmarks/mapping/samtools/{sample}.{ref}.rmdup.log"
-    threads: lambda wildcards, attempt: attempt * 4
+    threads: 2
     resources:
-        runtime=lambda wildcards, attempt: attempt * 720,
+        runtime="12h",
     wrapper:
         "v4.0.0/bio/samtools/merge"
 
@@ -227,9 +226,9 @@ rule realignertargetcreator:
         "logs/mapping/gatk/realignertargetcreator/{sample}.{ref}.log",
     benchmark:
         "benchmarks/mapping/gatk/realignertargetcreator/{sample}.{ref}.log"
-    threads: lambda wildcards, attempt: attempt * 2
+    threads: 2
     resources:
-        runtime=lambda wildcards, attempt: attempt * 720,
+        runtime="12h",
     wrapper:
         "v4.0.0/bio/gatk3/realignertargetcreator"
 
@@ -249,9 +248,9 @@ rule indelrealigner:
         "logs/mapping/gatk/indelrealigner/{sample}.{ref}.log",
     benchmark:
         "benchmarks/mapping/gatk/indelrealigner/{sample}.{ref}.log"
-    threads: lambda wildcards, attempt: attempt * 4
+    threads: 8
     resources:
-        runtime=lambda wildcards, attempt: attempt * 1440,
+        runtime="1d",
     wrapper:
         "v4.0.0/bio/gatk3/indelrealigner"
 
@@ -272,9 +271,9 @@ rule bam_clipoverlap:
         bamutil_container
     shadow:
         "minimal"
-    threads: lambda wildcards, attempt: attempt * 2
+    threads: 2
     resources:
-        runtime=lambda wildcards, attempt: attempt * 720,
+        runtime="12h",
     shell:
         """
         bam clipOverlap --in {input.bam} --out {output.bam} --stats 2> {log}
@@ -315,9 +314,9 @@ rule bam_clipoverlap_userbams:
         bamutil_container
     shadow:
         "minimal"
-    threads: lambda wildcards, attempt: attempt * 2
+    threads: 2
     resources:
-        runtime=lambda wildcards, attempt: attempt * 720,
+        runtime="12h",
     shell:
         """
         bam clipOverlap --in {input.bam} --out {output.bam} --stats 2> {log}
@@ -398,7 +397,7 @@ rule samtools_subsample:
         seed=config["params"]["samtools"]["subsampling_seed"],
         mapq=bam_subsample_mapq,
     resources:
-        runtime=lambda wildcards, attempt: attempt * 720,
+        runtime="12h",
     shell:
         """
         dp=$(awk '{{print $2}}' {input.depth})

--- a/workflow/rules/2.1_sample_qc.smk
+++ b/workflow/rules/2.1_sample_qc.smk
@@ -194,9 +194,8 @@ rule ind_unfiltered_depth:
     params:
         out=lambda w, output: os.path.splitext(output.arg)[0],
         maxdepth=config["params"]["angsd"]["maxdepth"],
-    threads: lambda wildcards, attempt: attempt
     resources:
-        runtime=lambda wildcards, attempt: attempt * 120,
+        runtime="2h",
     shell:
         """
         angsd -doDepth 1 -doCounts 1 -maxDepth {params.maxdepth} \
@@ -231,9 +230,8 @@ rule ind_mapQ_baseQ_depth:
         out=lambda w, output: os.path.splitext(output.arg)[0],
         extra=config["params"]["angsd"]["extra"],
         maxdepth=config["params"]["angsd"]["maxdepth"],
-    threads: lambda wildcards, attempt: attempt
     resources:
-        runtime=lambda wildcards, attempt: attempt * 120,
+        runtime="2h",
     shell:
         """
         angsd -doDepth 1 -doCounts 1 -maxDepth {params.maxdepth} \
@@ -271,9 +269,8 @@ rule ind_filtered_depth:
         baseQ=config["baseQ"],
         out=lambda w, output: os.path.splitext(output.arg)[0],
         maxdepth=config["params"]["angsd"]["maxdepth"],
-    threads: lambda wildcards, attempt: attempt
     resources:
-        runtime=lambda wildcards, attempt: attempt * 60,
+        runtime="1h",
     shell:
         """
         angsd -doDepth 1 -doCounts 1 -maxDepth {params.maxdepth} \
@@ -298,9 +295,8 @@ rule summarize_ind_depth:
         "benchmarks/summarize_ind_depth/{prefix}{dataset}.{ref}_{sample}{dp}_{group}.log"
     container:
         r_container
-    threads: lambda wildcards, attempt: attempt
     resources:
-        runtime="1h",
+        runtime="15m",
     script:
         "../scripts/calc_depth.R"
 
@@ -432,9 +428,8 @@ rule ibs_ref_bias_nofilts:
         mapQ=config["mapQ"],
         baseQ=config["baseQ"],
         out=lambda w, output: os.path.splitext(output.arg)[0],
-    threads: lambda wildcards, attempt: attempt
     resources:
-        runtime=lambda wildcards, attempt: attempt * 720,
+        runtime="12h",
     shell:
         r"""
         (angsd -doIBS 1 -bam {input.bam} -ref {input.ref} -nThreads {threads} \
@@ -485,9 +480,8 @@ rule ibs_ref_bias_filts:
         mapQ=config["mapQ"],
         baseQ=config["baseQ"],
         out=lambda w, output: os.path.splitext(output.arg)[0],
-    threads: lambda wildcards, attempt: attempt
     resources:
-        runtime=lambda wildcards, attempt: attempt * 720,
+        runtime="12h",
     shell:
         r"""
         (angsd -doIBS 1 -bam {input.bam} -ref {input.ref} -nThreads {threads} \

--- a/workflow/rules/2.1_sample_qc.smk
+++ b/workflow/rules/2.1_sample_qc.smk
@@ -54,7 +54,7 @@ rule qualimap:
     shell:
         """
         qualimap bamqc -bam {input.bam} --java-mem-size={resources.mem_mb}M \
-            -outdir {output.fold} 2> {log}
+            -outdir {output.fold} &> {log}
         """
 
 
@@ -80,8 +80,10 @@ rule qualimap_userprovided:
         runtime="6h",
     shell:
         """
+        unset DISPLAY
+
         qualimap bamqc -bam {input.bam} --java-mem-size={resources.mem_mb}M \
-            -outdir {output.fold} 2> {log}
+            -outdir {output.fold} &> {log}
         """
 
 

--- a/workflow/rules/2.2_dna_damage.smk
+++ b/workflow/rules/2.2_dna_damage.smk
@@ -3,7 +3,7 @@
 
 rule damageprofiler:
     """
-    Estimates varous metrics related to post-mortem DNA damage. Informative 
+    Estimates varous metrics related to post-mortem DNA damage. Informative
     rather than corrective.
     """
     input:
@@ -40,9 +40,8 @@ rule damageprofiler:
         damageprofiler_container
     params:
         out=lambda w, output: os.path.dirname(output[0]),
-    threads: lambda wildcards, attempt: attempt
     resources:
-        runtime=lambda wildcards, attempt: attempt * 60,
+        runtime="1h",
     shell:
         """
         damageprofiler -Xmx{resources.mem_mb}m -i {input.bam} -r {input.ref} \
@@ -52,7 +51,7 @@ rule damageprofiler:
 
 rule damageprofiler_userbam:
     """
-    Estimates varous metrics related to post-mortem DNA damage. Informative 
+    Estimates varous metrics related to post-mortem DNA damage. Informative
     rather than corrective. Done this time for BAMs provided by user.
     """
     input:
@@ -89,9 +88,8 @@ rule damageprofiler_userbam:
         damageprofiler_container
     params:
         out=lambda w, output: os.path.dirname(output[0]),
-    threads: lambda wildcards, attempt: attempt
     resources:
-        runtime=lambda wildcards, attempt: attempt * 60,
+        runtime="1h",
     shell:
         """
         damageprofiler -Xmx{resources.mem_mb}m -i {input.bam} -r {input.ref} \
@@ -124,7 +122,7 @@ rule mapDamage2_rescaling:
     params:
         extra="--rescale",
     resources:
-        runtime=1440,
+        runtime="1d",
     wrapper:
         "v4.0.0/bio/mapdamage2"
 

--- a/workflow/rules/3.1_safs.smk
+++ b/workflow/rules/3.1_safs.smk
@@ -50,8 +50,7 @@ rule angsd_doSaf_pop:
         mininddp=config["params"]["angsd"]["mindepthind"],
         out=lambda w, output: os.path.splitext(output.arg)[0],
     resources:
-        runtime=lambda wildcards, attempt: attempt * 180,
-    threads: lambda wildcards, attempt: attempt * 2
+        runtime="6h",
     shell:
         """
         angsd -doSaf 1 -bam {input.bam} -GL {params.gl_model} -ref {input.ref} \
@@ -102,7 +101,7 @@ rule realSFS_catsaf:
     params:
         out=lambda w, output: output[0].removesuffix(".saf.idx"),
     resources:
-        runtime=lambda wildcards, attempt: attempt * 60,
+        runtime="1h",
     shell:
         """
         realSFS cat {input.safs} -P 1 -outnames {params.out} 2> {log}

--- a/workflow/rules/3.2_beagles.smk
+++ b/workflow/rules/3.2_beagles.smk
@@ -44,9 +44,8 @@ rule angsd_doGlf2:
         minind=get_minind,
         mininddp=config["params"]["angsd"]["mindepthind"],
         out=lambda w, output: os.path.splitext(output.arg)[0],
-    threads: lambda wildcards, attempt: attempt
     resources:
-        runtime=lambda wildcards, attempt: attempt * 720,
+        runtime="12h",
     shell:
         """
         angsd -doGlf 2 -bam {input.bam} -GL {params.gl_model} -ref {input.ref} \
@@ -123,7 +122,7 @@ rule merge_maf:
 
 rule snpset:
     """
-    Extracts SNP coordinates from maf file to get a list of variable sites in the 
+    Extracts SNP coordinates from maf file to get a list of variable sites in the
     dataset.
     """
     input:

--- a/workflow/rules/3.3_mafs.smk
+++ b/workflow/rules/3.3_mafs.smk
@@ -67,9 +67,8 @@ rule angsd_doMaf:
         minind=get_minind,
         mininddp=config["params"]["angsd"]["mindepthind"],
         out=lambda w, output: os.path.splitext(output.arg)[0],
-    threads: lambda wildcards, attempt: attempt
     resources:
-        runtime=lambda wildcards, attempt: attempt * 720,
+        runtime="12h",
     shell:
         """
         angsd -bam {input.bam} -GL {params.gl_model} -ref {input.ref} \

--- a/workflow/rules/4.0_estimate_LD.smk
+++ b/workflow/rules/4.0_estimate_LD.smk
@@ -27,11 +27,11 @@ rule ngsLD_estLD:
         "benchmarks/{dataset}/ngsLD/estLD/{path}/{dataset}.{ref}_{population}{dp}_chunk{chunk}_{sites}-filts.ld_maxkbdist-{maxkb}_rndsample-{rndsmp}.log"
     container:
         ngsld_container
-    threads: lambda wildcards, attempt: attempt
+    threads: 4
     wildcard_constraints:
         path="beagles/pruned/ngsLD|analyses/ngsLD/chunks",
     resources:
-        runtime=lambda wildcards, attempt: attempt * 720,
+        runtime="12h",
     shell:
         r"""
         (zcat {input.beagle} | awk '{{print $1}}' | sed 's/\(.*\)_/\1\t/' \

--- a/workflow/rules/4.1_linkage_pruning.smk
+++ b/workflow/rules/4.1_linkage_pruning.smk
@@ -46,9 +46,8 @@ rule prune_chunk_beagle:
         "benchmarks/{dataset}/ngsLD/prune_beagle/{dataset}.{ref}_{population}{dp}_chunk{chunk}_{sites}-filts.pruned_maxkbdist-{maxkb}_minr2-{r2}.log"
     container:
         pandas_container
-    threads: lambda wildcards, attempt: attempt
     resources:
-        runtime="3h",
+        runtime="12",
     script:
         "../scripts/prune_beagle.py"
 

--- a/workflow/rules/4.2_linkage_decay.smk
+++ b/workflow/rules/4.2_linkage_decay.smk
@@ -52,7 +52,6 @@ rule fit_LD_decay:
         "benchmarks/{dataset}/ngsLD/fit_LD_decay/{dataset}.{ref}_{population}{dp}_{sites}-filts.log"
     container:
         ngsld_container
-    threads: lambda w, attempt: attempt
     resources:
         runtime="8h",
     params:

--- a/workflow/rules/5.0_relatedness.smk
+++ b/workflow/rules/5.0_relatedness.smk
@@ -87,8 +87,7 @@ rule doGlf1_ibsrelate:
         baseQ=config["baseQ"],
         out=lambda w, output: os.path.splitext(output.arg)[0],
     resources:
-        runtime=lambda wildcards, attempt: attempt * 360,
-    threads: lambda wildcards, attempt: attempt * 2
+        runtime="6h",
     shell:
         """
         angsd -doGlf 1 -bam {input.bam} -GL {params.gl_model} -ref {input.ref} \
@@ -117,8 +116,7 @@ rule ibsrelate:
         maxsites=config["chunk_size"],
         out=lambda w, output: os.path.splitext(output[0])[0],
     resources:
-        runtime="7d",
-    threads: lambda wildcards, attempt: attempt * 10
+        runtime="3d",
     shell:
         """
         ibs -glf {input} -model 0 -nInd {params.nind} -allpairs 1 \
@@ -203,11 +201,10 @@ rule ngsrelate_ibsrelate_only:
         "logs/{dataset}/kinship/ngsrelate/{dataset}.{ref}_{population}{dp}_{sites}-filts.ibsrelate-nofreq.log",
     container:
         ngsrelate_container
-    threads: lambda wildcards, attempt: attempt * 4
     params:
         nind=get_nind,
     resources:
-        runtime=lambda wildcards, attempt: attempt * 360,
+        runtime="6h",
     shell:
         r"""
         (nsites=$(zcat {input.beagle} | tail -n +2 | wc -l)
@@ -240,11 +237,10 @@ rule ngsrelate_freqbased:
         "logs/{dataset}/kinship/ngsrelate/{dataset}.{ref}_{population}{dp}_{sites}-filts.log",
     container:
         ngsrelate_container
-    threads: lambda wildcards, attempt: attempt * 4
     params:
         nind=get_nind,
     resources:
-        runtime=lambda wildcards, attempt: attempt * 360,
+        runtime="6h",
     shell:
         r"""
         (nsites=$(zcat {input.beagle} | tail -n +2 | wc -l)

--- a/workflow/rules/6.0_pca.smk
+++ b/workflow/rules/6.0_pca.smk
@@ -3,8 +3,8 @@
 
 rule remove_excl_pca_admix:
     """
-    Excludes requested individuals from beagle file only for PCA and Admix. This is 
-    largely to exclude close relatives from these analyses (where they can impact 
+    Excludes requested individuals from beagle file only for PCA and Admix. This is
+    largely to exclude close relatives from these analyses (where they can impact
     results), while allowing them in all other analyses.
     """
     input:
@@ -51,7 +51,7 @@ rule pca_pcangsd:
         pcangsd_container
     params:
         prefix=lambda w, output: os.path.splitext(output.cov)[0],
-    threads: lambda wildcards, attempt: attempt
+    threads: 2
     resources:
         runtime="4h",
     group:
@@ -87,7 +87,7 @@ rule plot_pca:
     container:
         r_container
     resources:
-        runtime="15m",
+        runtime="1h",
     group:
         "pca"
     script:

--- a/workflow/rules/6.1_admixture.smk
+++ b/workflow/rules/6.1_admixture.smk
@@ -3,8 +3,8 @@
 
 rule ngsAdmix:
     """
-    Performs individual admixture analyses for a given K, performing several replicates 
-    and preserving the replicate with the highest likelihood. After $minreps, 
+    Performs individual admixture analyses for a given K, performing several replicates
+    and preserving the replicate with the highest likelihood. After $minreps,
     convergence is assessed and replicates cease when convergence is reached or $reps
     replicates have been performed.
     """
@@ -33,7 +33,7 @@ rule ngsAdmix:
         conv=config["params"]["ngsadmix"]["conv"],
     threads: 4
     resources:
-        runtime="7d",
+        runtime="3d",
     script:
         "../scripts/ngsadmix.sh"
 

--- a/workflow/rules/7.0_SFS.smk
+++ b/workflow/rules/7.0_SFS.smk
@@ -25,9 +25,9 @@ rule realSFS_1dSFS:
         "benchmarks/{dataset}/realSFS/1dSFS/{dataset}.{ref}_{population}{dp}_{sites}-filts.log"
     params:
         fold=config["params"]["realsfs"]["fold"],
-    threads: lambda wildcards, attempt: attempt * 2
+    threads: 4
     resources:
-        runtime=lambda wildcards, attempt: attempt * 720,
+        runtime="1d",
     shell:
         """
         realSFS {input.saf} -fold {params.fold} -P {threads} \
@@ -60,9 +60,9 @@ rule realSFS_1dSFS_bootstrap:
     params:
         fold=config["params"]["realsfs"]["fold"],
         boot=config["params"]["realsfs"]["sfsboot"],
-    threads: lambda wildcards, attempt: attempt * 2
+    threads: 4
     resources:
-        runtime="7d",
+        runtime="3d",
     shell:
         """
         realSFS {input.saf} -fold {params.fold} -P {threads} \
@@ -100,9 +100,9 @@ rule realSFS_2dSFS:
         "benchmarks/{dataset}/realSFS/2dSFS/{dataset}.{ref}_{population1}-{population2}{dp}_{sites}-filts.log"
     params:
         fold=config["params"]["realsfs"]["fold"],
-    threads: lambda wildcards, attempt: attempt * 2
+    threads: 4
     resources:
-        runtime=lambda wildcards, attempt: attempt * 720,
+        runtime="12h",
     shell:
         """
         realSFS {input.saf1} {input.saf2} -fold {params.fold} \
@@ -141,9 +141,9 @@ rule realSFS_2dSFS_bootstrap:
     params:
         fold=config["params"]["realsfs"]["fold"],
         boot=config["params"]["realsfs"]["sfsboot"],
-    threads: lambda wildcards, attempt: attempt * 2
+    threads: 4
     resources:
-        runtime="7d",
+        runtime="3d",
     shell:
         """
         realSFS {input.saf1} {input.saf2} -fold {params.fold} \


### PR DESCRIPTION
Qualimap seemed to be having some issues on headless systems, so now I unset DISPLAY before running. It also logs to standard out rather than standard error, so I redirect both to the log file now.

Default resources weren't always so friendly. I included 'attempt' scaling by default where I found it useful, but this can just eat through folks' core hours if there is just an actual error, better to let them set it themselves when desired. Also dropped down some runtime limits and thread counts where they might be higher than most expect, these can be increased by users when needed. I recommend bumping up mapping threads if you have threads to spare on your nodes, bwa scales really well. Few other parts scale with threads well, so are kept low. Runtime limits capped at 3 days, as this seems to be a common SLURM limit for a lot of people, so this prevents out of the box failures based on that.